### PR TITLE
fix(trackers): update DCC to correct abbreviation and name

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can check out a few other, longer, screenshots in the docs folder.
 | DarkPeers             | UNIT3D    | ✅ Verified            |                                                   |
 | Luminarr              | UNIT3D    | 🟡 Unverified          |                                                   |
 | CathodeRayTube (CRT)  | UNIT3D    | 📋 Draft               |                                                   |
-| DigitalCore           | Custom    | 📋 Needs adapter       |                                                   |
+| DigitalCore           | Custom    | ✅ Verified            |                                                   |
 | HDBits                | Custom    | 📋 Needs adapter       |                                                   |
 | SecretCinema          | Custom    | 📋 Needs adapter       |                                                   |
 | SportsCult            | Custom    | 📋 Needs adapter       |                                                   |

--- a/src/data/trackers/digitalcore.ts
+++ b/src/data/trackers/digitalcore.ts
@@ -5,8 +5,8 @@ import type { TrackerRegistryEntry } from "@/data/tracker-registry"
 export const digitalcore: TrackerRegistryEntry = {
   // ── Identity ────────────────────────────────────────────────────────
   slug: "digitalcore",
-  name: "DigitalCore",
-  abbreviation: "DC",
+  name: "DigitalCore.Club",
+  abbreviation: "DCC",
   url: "https://digitalcore.club",
   description:
     "Scene-oriented 0day/general tracker with 1.5M+ torrents. Movies, TV, music, apps, games, ebooks.",


### PR DESCRIPTION
Using https://trackerpathways.org/directory as source for official names and abbreviations