### PR TITLE
fix(auth): support qBittorrent 5.2+ login and session cookie

### DIFF
--- a/src/lib/download-clients/__tests__/qbt-adapter.test.ts
+++ b/src/lib/download-clients/__tests__/qbt-adapter.test.ts
@@ -6,7 +6,7 @@ vi.mock("@/lib/download-clients/qbt/transport", () => ({
   buildBaseUrl: vi.fn(
     (host: string, port: number, ssl: boolean) => `${ssl ? "https" : "http"}://${host}:${port}`
   ),
-  login: vi.fn().mockResolvedValue("test-sid"),
+  login: vi.fn().mockResolvedValue({ name: "SID", value: "test-sid" }),
   getTorrents: vi.fn().mockResolvedValue([
     {
       hash: "abc",
@@ -64,8 +64,8 @@ vi.mock("@/lib/download-clients/qbt/transport", () => ({
       _s: boolean,
       _u: string,
       _pw: string,
-      op: (baseUrl: string, sid: string) => unknown
-    ) => op("http://localhost:8080", "test-sid")
+      op: (baseUrl: string, sid: { name: string; value: string }) => unknown
+    ) => op("http://localhost:8080", { name: "SID", value: "test-sid" })
   ),
 }))
 
@@ -140,7 +140,7 @@ describe("QbtClientAdapter", () => {
     await adapter.getTorrents({ tag: "aither", filter: "active" })
     expect(getTorrents).toHaveBeenCalledWith(
       expect.any(String),
-      expect.any(String),
+      { name: "SID", value: "test-sid" },
       "aither",
       "active"
     )
@@ -158,7 +158,7 @@ describe("QbtClientAdapter", () => {
 
   it("returns normalized DeltaSyncResponse from getDeltaSync", async () => {
     const data = await adapter.getDeltaSync?.(0)
-    expect(syncMaindata).toHaveBeenCalledWith(expect.any(String), expect.any(String), 0)
+    expect(syncMaindata).toHaveBeenCalledWith(expect.any(String), { name: "SID", value: "test-sid" }, 0)
 
     // Top-level fields pass through
     expect(data?.rid).toBe(1)

--- a/src/lib/download-clients/__tests__/qbt.test.ts
+++ b/src/lib/download-clients/__tests__/qbt.test.ts
@@ -52,6 +52,21 @@ describe("login", () => {
     expect(sid).toBe("abc123xyz")
   })
 
+  it("returns the SID value from a QBT_SID_<port> cookie (qBittorrent 5.2+)", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      text: async () => "",
+      headers: new Headers({
+        "set-cookie":
+          "QBT_SID_8080=YYhsGDAcg8mu89vWPnxXgkH1xkjVQK5h; HttpOnly; SameSite=Lax; expires=Wed, 05-Aug-2026 01:58:51 GMT; path=/",
+      }),
+    } as Response)
+
+    const sid = await login("localhost", 8080, false, "admin", "password")
+    expect(sid).toBe("YYhsGDAcg8mu89vWPnxXgkH1xkjVQK5h")
+  })
+
   it("sends a POST to the correct URL with form-encoded body", async () => {
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce({
       ok: true,

--- a/src/lib/download-clients/__tests__/qbt.test.ts
+++ b/src/lib/download-clients/__tests__/qbt.test.ts
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { TorrentRecord } from "@/lib/download-clients"
 import { aggregateByTag } from "../aggregator"
-import { buildBaseUrl, getTorrents, getTransferInfo, login } from "../qbt/transport"
+import { buildBaseUrl, getTorrents, getTransferInfo, login, type SidCookie } from "../qbt/transport"
 import type { QbtTorrent } from "../qbt/types"
 
 // ---------------------------------------------------------------------------
@@ -28,7 +28,7 @@ describe("login", () => {
     vi.restoreAllMocks()
   })
 
-  it("returns the SID cookie value on successful login", async () => {
+  it("returns the SID cookie name and value on successful login", async () => {
     vi.spyOn(global, "fetch").mockResolvedValueOnce({
       ok: true,
       status: 200,
@@ -37,10 +37,10 @@ describe("login", () => {
     } as Response)
 
     const sid = await login("localhost", 8080, false, "admin", "password")
-    expect(sid).toBe("abc123xyz")
+    expect(sid).toEqual({ name: "SID", value: "abc123xyz" })
   })
 
-  it("returns the SID cookie value on successful login with 204 No Content (qBittorrent 5.2+)", async () => {
+  it("returns the SID cookie name and value on successful login with 204 No Content (qBittorrent 5.2+)", async () => {
     vi.spyOn(global, "fetch").mockResolvedValueOnce({
       ok: true,
       status: 204,
@@ -49,10 +49,10 @@ describe("login", () => {
     } as Response)
 
     const sid = await login("localhost", 8080, false, "admin", "password")
-    expect(sid).toBe("abc123xyz")
+    expect(sid).toEqual({ name: "SID", value: "abc123xyz" })
   })
 
-  it("returns the SID value from a QBT_SID_<port> cookie (qBittorrent 5.2+)", async () => {
+  it("returns the actual cookie name and value from a QBT_SID_<port> cookie (qBittorrent 5.2+)", async () => {
     vi.spyOn(global, "fetch").mockResolvedValueOnce({
       ok: true,
       status: 204,
@@ -64,7 +64,7 @@ describe("login", () => {
     } as Response)
 
     const sid = await login("localhost", 8080, false, "admin", "password")
-    expect(sid).toBe("YYhsGDAcg8mu89vWPnxXgkH1xkjVQK5h")
+    expect(sid).toEqual({ name: "QBT_SID_8080", value: "YYhsGDAcg8mu89vWPnxXgkH1xkjVQK5h" })
   })
 
   it("sends a POST to the correct URL with form-encoded body", async () => {
@@ -160,6 +160,8 @@ describe("login", () => {
 // ---------------------------------------------------------------------------
 
 describe("getTorrents", () => {
+  const sid: SidCookie = { name: "SID", value: "mysid" }
+
   beforeEach(() => {
     vi.restoreAllMocks()
   })
@@ -203,22 +205,34 @@ describe("getTorrents", () => {
       json: async () => mockTorrents,
     } as Response)
 
-    const result = await getTorrents("http://localhost:8080", "mysid")
+    const result = await getTorrents("http://localhost:8080", sid)
     expect(result).toHaveLength(1)
     expect(result[0].hash).toBe("abc")
     expect(result[0].state).toBe("uploading")
   })
 
-  it("sends SID cookie in request", async () => {
+  it("sends the SID cookie under its own name in request", async () => {
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce({
       ok: true,
       json: async () => [],
     } as Response)
 
-    await getTorrents("http://localhost:8080", "testSID99")
+    await getTorrents("http://localhost:8080", { name: "SID", value: "testSID99" })
 
     const init = fetchSpy.mock.calls[0][1] as RequestInit
     expect((init.headers as Record<string, string>).Cookie).toBe("SID=testSID99")
+  })
+
+  it("sends the cookie under a QBT_SID_<port>-style name, not a hardcoded SID", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    } as Response)
+
+    await getTorrents("http://localhost:8080", { name: "QBT_SID_8080", value: "testSID99" })
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit
+    expect((init.headers as Record<string, string>).Cookie).toBe("QBT_SID_8080=testSID99")
   })
 
   it("calls the correct endpoint", async () => {
@@ -227,7 +241,7 @@ describe("getTorrents", () => {
       json: async () => [],
     } as Response)
 
-    await getTorrents("http://localhost:8080", "sid")
+    await getTorrents("http://localhost:8080", sid)
 
     expect(fetchSpy.mock.calls[0][0]).toBe("http://localhost:8080/api/v2/torrents/info")
   })
@@ -238,7 +252,7 @@ describe("getTorrents", () => {
       json: async () => [],
     } as Response)
 
-    await getTorrents("http://localhost:8080", "sid", "aither")
+    await getTorrents("http://localhost:8080", sid, "aither")
 
     expect(fetchSpy.mock.calls[0][0]).toBe("http://localhost:8080/api/v2/torrents/info?tag=aither")
   })
@@ -249,7 +263,7 @@ describe("getTorrents", () => {
       json: async () => [],
     } as Response)
 
-    await getTorrents("http://localhost:8080", "sid", "cross seed")
+    await getTorrents("http://localhost:8080", sid, "cross seed")
 
     expect(fetchSpy.mock.calls[0][0]).toBe(
       "http://localhost:8080/api/v2/torrents/info?tag=cross%20seed"
@@ -263,7 +277,7 @@ describe("getTorrents", () => {
       statusText: "Forbidden",
     } as Response)
 
-    await expect(getTorrents("http://localhost:8080", "sid")).rejects.toThrow("Session expired")
+    await expect(getTorrents("http://localhost:8080", sid)).rejects.toThrow("Session expired")
   })
 
   it("throws on non-ok response", async () => {
@@ -273,7 +287,7 @@ describe("getTorrents", () => {
       statusText: "Internal Server Error",
     } as Response)
 
-    await expect(getTorrents("http://localhost:8080", "sid")).rejects.toThrow(
+    await expect(getTorrents("http://localhost:8080", sid)).rejects.toThrow(
       "qBittorrent API error: 500 Internal Server Error"
     )
   })
@@ -283,7 +297,7 @@ describe("getTorrents", () => {
       new DOMException("signal timed out", "TimeoutError")
     )
 
-    await expect(getTorrents("http://localhost:8080", "sid")).rejects.toThrow(
+    await expect(getTorrents("http://localhost:8080", sid)).rejects.toThrow(
       "Request to localhost timed out after 15s"
     )
   })
@@ -291,7 +305,7 @@ describe("getTorrents", () => {
   it("throws a connection error on network failure", async () => {
     vi.spyOn(global, "fetch").mockRejectedValueOnce(new Error("fetch failed"))
 
-    await expect(getTorrents("http://192.168.1.1:8080", "sid")).rejects.toThrow(
+    await expect(getTorrents("http://192.168.1.1:8080", sid)).rejects.toThrow(
       "Failed to connect to 192.168.1.1"
     )
   })
@@ -302,6 +316,8 @@ describe("getTorrents", () => {
 // ---------------------------------------------------------------------------
 
 describe("getTransferInfo", () => {
+  const sid: SidCookie = { name: "SID", value: "mysid" }
+
   beforeEach(() => {
     vi.restoreAllMocks()
   })
@@ -317,7 +333,7 @@ describe("getTransferInfo", () => {
       }),
     } as Response)
 
-    const info = await getTransferInfo("http://localhost:8080", "mysid")
+    const info = await getTransferInfo("http://localhost:8080", sid)
     expect(info.up_info_speed).toBe(2048)
     expect(info.dl_info_speed).toBe(4096)
   })
@@ -328,21 +344,33 @@ describe("getTransferInfo", () => {
       json: async () => ({ up_info_speed: 0, dl_info_speed: 0, up_info_data: 0, dl_info_data: 0 }),
     } as Response)
 
-    await getTransferInfo("http://localhost:8080", "sid")
+    await getTransferInfo("http://localhost:8080", sid)
 
     expect(fetchSpy.mock.calls[0][0]).toBe("http://localhost:8080/api/v2/transfer/info")
   })
 
-  it("sends SID cookie in request", async () => {
+  it("sends the SID cookie under its own name in request", async () => {
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce({
       ok: true,
       json: async () => ({ up_info_speed: 0, dl_info_speed: 0, up_info_data: 0, dl_info_data: 0 }),
     } as Response)
 
-    await getTransferInfo("http://localhost:8080", "mySID")
+    await getTransferInfo("http://localhost:8080", { name: "SID", value: "mySID" })
 
     const init = fetchSpy.mock.calls[0][1] as RequestInit
     expect((init.headers as Record<string, string>).Cookie).toBe("SID=mySID")
+  })
+
+  it("sends the cookie under a QBT_SID_<port>-style name, not a hardcoded SID", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ up_info_speed: 0, dl_info_speed: 0, up_info_data: 0, dl_info_data: 0 }),
+    } as Response)
+
+    await getTransferInfo("http://localhost:8080", { name: "QBT_SID_8091", value: "mySID" })
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit
+    expect((init.headers as Record<string, string>).Cookie).toBe("QBT_SID_8091=mySID")
   })
 
   it("throws on non-ok response", async () => {
@@ -352,7 +380,7 @@ describe("getTransferInfo", () => {
       statusText: "Unauthorized",
     } as Response)
 
-    await expect(getTransferInfo("http://localhost:8080", "sid")).rejects.toThrow(
+    await expect(getTransferInfo("http://localhost:8080", sid)).rejects.toThrow(
       "qBittorrent API error: 401 Unauthorized"
     )
   })

--- a/src/lib/download-clients/__tests__/qbt.test.ts
+++ b/src/lib/download-clients/__tests__/qbt.test.ts
@@ -67,6 +67,38 @@ describe("login", () => {
     expect(sid).toEqual({ name: "QBT_SID_8080", value: "YYhsGDAcg8mu89vWPnxXgkH1xkjVQK5h" })
   })
 
+  it("picks the real QBT_SID_<port> cookie over a decoy cookie whose name merely contains SID as a substring", async () => {
+    const headers = new Headers()
+    headers.append("set-cookie", "SIDCC=fakevalue123; Path=/")
+    headers.append("set-cookie", "QBT_SID_8080=realvalue456; HttpOnly; Path=/")
+
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      text: async () => "",
+      headers,
+    } as Response)
+
+    const sid = await login("localhost", 8080, false, "admin", "password")
+    expect(sid).toEqual({ name: "QBT_SID_8080", value: "realvalue456" })
+  })
+
+  it("does not bleed the SID cookie's value into a second comma-joined Set-Cookie header when the SID cookie has no trailing attributes", async () => {
+    const headers = new Headers()
+    headers.append("set-cookie", "QBT_SID_8080=realvalue456")
+    headers.append("set-cookie", "other=somethingelse; Path=/")
+
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      text: async () => "",
+      headers,
+    } as Response)
+
+    const sid = await login("localhost", 8080, false, "admin", "password")
+    expect(sid).toEqual({ name: "QBT_SID_8080", value: "realvalue456" })
+  })
+
   it("sends a POST to the correct URL with form-encoded body", async () => {
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce({
       ok: true,

--- a/src/lib/download-clients/__tests__/qbt.test.ts
+++ b/src/lib/download-clients/__tests__/qbt.test.ts
@@ -31,7 +31,20 @@ describe("login", () => {
   it("returns the SID cookie value on successful login", async () => {
     vi.spyOn(global, "fetch").mockResolvedValueOnce({
       ok: true,
+      status: 200,
       text: async () => "Ok.",
+      headers: new Headers({ "set-cookie": "SID=abc123xyz; Path=/; HttpOnly" }),
+    } as Response)
+
+    const sid = await login("localhost", 8080, false, "admin", "password")
+    expect(sid).toBe("abc123xyz")
+  })
+
+  it("returns the SID cookie value on successful login with 204 No Content (qBittorrent 5.2+)", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      text: async () => "",
       headers: new Headers({ "set-cookie": "SID=abc123xyz; Path=/; HttpOnly" }),
     } as Response)
 
@@ -60,6 +73,7 @@ describe("login", () => {
   it("throws Authentication failed when response text is not Ok.", async () => {
     vi.spyOn(global, "fetch").mockResolvedValueOnce({
       ok: true,
+      status: 200,
       text: async () => "Fails.",
       headers: new Headers({}),
     } as Response)

--- a/src/lib/download-clients/qbt/transport.ts
+++ b/src/lib/download-clients/qbt/transport.ts
@@ -57,20 +57,23 @@ export function buildBaseUrl(host: string, port: number, ssl: boolean): string {
 // SID session cache to avoid re-authenticating on every poll cycle.
 // ---------------------------------------------------------------------------
 
+/** The session cookie qBittorrent assigns at login — name varies by version/port. */
+export type SidCookie = { name: string; value: string }
+
 const gSid = globalThis as typeof globalThis & {
-  __qbtSidCache?: Map<string, string>
+  __qbtSidCache?: Map<string, SidCookie>
 }
 if (!gSid.__qbtSidCache) gSid.__qbtSidCache = new Map()
 const sidCache = gSid.__qbtSidCache
 
-/** Get a cached SID or perform a fresh login. */
+/** Get a cached session cookie or perform a fresh login. */
 export async function getSession(
   host: string,
   port: number,
   ssl: boolean,
   username: string,
   password: string
-): Promise<{ baseUrl: string; sid: string }> {
+): Promise<{ baseUrl: string; sid: SidCookie }> {
   const baseUrl = buildBaseUrl(host, port, ssl)
   const cached = sidCache.get(baseUrl)
   if (cached) return { baseUrl, sid: cached }
@@ -107,7 +110,7 @@ export async function withSessionRetry<T>(
   ssl: boolean,
   username: string,
   password: string,
-  op: (baseUrl: string, sid: string) => Promise<T>
+  op: (baseUrl: string, sid: SidCookie) => Promise<T>
 ): Promise<T> {
   const { baseUrl, sid } = await getSession(host, port, ssl, username, password)
   try {
@@ -128,7 +131,7 @@ export async function login(
   ssl: boolean,
   username: string,
   password: string
-): Promise<string> {
+): Promise<SidCookie> {
   const baseUrl = buildBaseUrl(host, port, ssl)
   const url = `${baseUrl}/api/v2/auth/login`
   const body = new URLSearchParams({ username, password }).toString()
@@ -163,26 +166,29 @@ export async function login(
 
   // qBittorrent 5.2+ names its session cookie `QBT_SID_<port>` (the WebUI's
   // own listen port baked into the name) instead of the legacy plain `SID`,
-  // so match any cookie whose name contains SID as a token.
+  // so match any cookie whose name contains SID as a token, and capture the
+  // actual name — the server rejects the value if sent back under a
+  // different cookie name (confirmed live: sending the correct value under
+  // the wrong name returns 403).
   const setCookie = response.headers.get("set-cookie") ?? ""
-  const match = setCookie.match(/(?:^|,\s*|;\s*)[\w-]*SID[\w-]*=([^;]+)/)
+  const match = setCookie.match(/(?:^|,\s*|;\s*)([\w-]*SID[\w-]*)=([^;]+)/)
   if (!match) {
     throw new Error("Authentication failed — SID cookie not found in response")
   }
 
-  return match[1]
+  return { name: match[1], value: match[2] }
 }
 
 async function qbtFetch(
   url: string,
   host: string,
   baseUrl: string,
-  sid: string
+  sid: SidCookie
 ): Promise<Response> {
   let response: Response
   try {
     response = await fetch(url, {
-      headers: { Cookie: `SID=${sid}` },
+      headers: { Cookie: `${sid.name}=${sid.value}` },
       signal: AbortSignal.timeout(ADAPTER_FETCH_TIMEOUT_MS),
     })
   } catch (err) {
@@ -241,7 +247,7 @@ export function parseCachedTorrents(raw: unknown): SlimTorrent[] {
 
 export async function getTorrents(
   baseUrl: string,
-  sid: string,
+  sid: SidCookie,
   tag?: string,
   filter?: string
 ): Promise<QbtTorrent[]> {
@@ -255,7 +261,7 @@ export async function getTorrents(
   return response.json() as Promise<QbtTorrent[]>
 }
 
-export async function getTransferInfo(baseUrl: string, sid: string): Promise<QbtTransferInfo> {
+export async function getTransferInfo(baseUrl: string, sid: SidCookie): Promise<QbtTransferInfo> {
   const url = `${baseUrl}/api/v2/transfer/info`
   const host = new URL(baseUrl).hostname
   const response = await qbtFetch(url, host, baseUrl, sid)
@@ -264,7 +270,7 @@ export async function getTransferInfo(baseUrl: string, sid: string): Promise<Qbt
 
 export async function syncMaindata(
   baseUrl: string,
-  sid: string,
+  sid: SidCookie,
   rid: number
 ): Promise<QbtMaindataResponse> {
   const url = `${baseUrl}/api/v2/sync/maindata?rid=${rid}`

--- a/src/lib/download-clients/qbt/transport.ts
+++ b/src/lib/download-clients/qbt/transport.ts
@@ -161,8 +161,11 @@ export async function login(
     throw new Error("Authentication failed — check username and password")
   }
 
+  // qBittorrent 5.2+ names its session cookie `QBT_SID_<port>` (the WebUI's
+  // own listen port baked into the name) instead of the legacy plain `SID`,
+  // so match any cookie whose name contains SID as a token.
   const setCookie = response.headers.get("set-cookie") ?? ""
-  const match = setCookie.match(/SID=([^;]+)/)
+  const match = setCookie.match(/(?:^|,\s*|;\s*)[\w-]*SID[\w-]*=([^;]+)/)
   if (!match) {
     throw new Error("Authentication failed — SID cookie not found in response")
   }

--- a/src/lib/download-clients/qbt/transport.ts
+++ b/src/lib/download-clients/qbt/transport.ts
@@ -157,7 +157,7 @@ export async function login(
   }
 
   const text = await response.text()
-  if (text !== "Ok.") {
+  if (text !== "Ok." && response.status !== 204) {
     throw new Error("Authentication failed — check username and password")
   }
 

--- a/src/lib/download-clients/qbt/transport.ts
+++ b/src/lib/download-clients/qbt/transport.ts
@@ -166,17 +166,31 @@ export async function login(
 
   // qBittorrent 5.2+ names its session cookie `QBT_SID_<port>` (the WebUI's
   // own listen port baked into the name) instead of the legacy plain `SID`,
-  // so match any cookie whose name contains SID as a token, and capture the
-  // actual name — the server rejects the value if sent back under a
-  // different cookie name (confirmed live: sending the correct value under
-  // the wrong name returns 403).
-  const setCookie = response.headers.get("set-cookie") ?? ""
-  const match = setCookie.match(/(?:^|,\s*|;\s*)([\w-]*SID[\w-]*)=([^;]+)/)
-  if (!match) {
+  // so match that pattern specifically — the server rejects the value if sent
+  // back under a different cookie name (confirmed live: sending the correct
+  // value under the wrong name returns 403). `getSetCookie()` returns each
+  // Set-Cookie response header as its own array element, unlike `.get()`
+  // which comma-joins them into a single string that's unsafe to regex
+  // across (cookie values can legally contain commas).
+  const sid = response.headers
+    .getSetCookie()
+    .map((cookie): SidCookie | null => {
+      const eq = cookie.indexOf("=")
+      if (eq === -1) return null
+      const name = cookie.slice(0, eq).trim()
+      const value = cookie.slice(eq + 1).split(";", 1)[0].trim()
+      return { name, value }
+    })
+    .find((cookie): cookie is SidCookie => {
+      if (!cookie) return false
+      return cookie.name === "SID" || /^QBT_SID_\d+$/.test(cookie.name)
+    })
+
+  if (!sid) {
     throw new Error("Authentication failed — SID cookie not found in response")
   }
 
-  return { name: match[1], value: match[2] }
+  return sid
 }
 
 async function qbtFetch(


### PR DESCRIPTION
Fixes qBittorrent client connections against qBittorrent 5.2.0+ (released 2026-05-03), which are currently broken for every user on that version or newer.

## What broke

qBittorrent 5.2.0 changed two things about `/api/v2/auth/login` at once, and we depend on both:

1. **Login success is now `204 No Content` with an empty body.** `loginAction()` no longer calls `setResult()`, and `webapplication.cpp` maps a null result to 204. We required the body to equal `"Ok."`, so login threw "Authentication failed — check username and password" on *correct* credentials.
2. **The session cookie was renamed** from `SID` to `QBT_SID_<port>`:
   ```cpp
   const QString SESSION_COOKIE_NAME_PREFIX = u"QBT_SID_"_s;
   m_sessionCookieName = SESSION_COOKIE_NAME_PREFIX + QString::number(pref->getWebUIPort());
   ```
   We matched `/SID=([^;]+)/`, which doesn't match `QBT_SID_8080=...`, and we sent the value back as `Cookie: SID=...`, a name the server's exact-name lookup ignores. Either break alone is fatal.

Bad credentials also now return `401` instead of `200` with body `"Fails."`.

## What this changes

- Accept `204` as login success alongside the legacy `200` + `"Ok."`.
- Model the session cookie as `SidCookie { name, value }` and thread it through `getSession`, `withSessionRetry`, `qbtFetch`, `getTorrents`, `getTransferInfo`, and `syncMaindata`. The cookie **name** is server-determined, so it can't stay a hardcoded constant.
- Read the name off `Set-Cookie` rather than deriving it. The port in the name is qBittorrent's *own configured WebUI port*, not the port we connected on — behind a reverse proxy on :443 it's still the internal port, so deriving it from our config would be wrong.
- Match `^QBT_SID_\d+$` or the legacy exact `SID`, keeping ≤5.1 servers working.
- Parse each `Set-Cookie` header individually via `getSetCookie()`. `.get("set-cookie")` comma-joins multiple headers, and cookie values and `Expires` dates legally contain commas, so regexing across the joined string was unsafe. This fixes a latent bug that predates 5.2.

Net production change: 38 insertions, 15 deletions in `src/lib/download-clients/qbt/transport.ts`.

## Verification

Behavior confirmed against qBittorrent source at the `release-5.2.0` tag (`src/webui/webapplication.cpp`, `src/webui/api/authcontroller.cpp`). Note the GitHub wiki and most third-party docs still describe the 5.0 API and show plain `SID=` — they are stale on this point.

Local run against this branch:

```
tsc               exit=0
biome             exit=0    556 files, no issues
security-audit    exit=0    0 critical, 0 warning, 38/38 (matches baseline)
vitest            exit=0    103 files, 2794 tests (+6)
```

New tests cover 204 login, the `QBT_SID_<port>` name, a decoy cookie whose name merely contains `SID` as a substring, and the comma-joined-header bleed case.

## Provenance

These four commits are cherry-picked from #175, authored by @clawdbrunner, and are unrelated to that PR's tracker-adapter work — they touch only `src/lib/download-clients/`. Split out so the client fix can ship without waiting on that review. When #175 rebases, git will recognize these as already applied and drop them automatically.

## Not included

- Bad credentials on 5.2+ still surface as `qBittorrent API error: 401 Unauthorized` rather than the friendlier credentials message, because the generic `!response.ok` check runs before the body check. Worth a follow-up.
- API-key auth (`Authorization: Bearer`, qBittorrent 5.2.0+ / WebAPI 2.15.1) would remove cookie handling entirely, but `auth/*` is forbidden under a key so `testConnection()` would need to probe `transfer/info` instead. Separate change.
