### PR TITLE
fix(trackers): TorrentLeech 2FA, login correctness, proxy, and profile parsing

### DIFF
--- a/src/components/AddTrackerDialog.tsx
+++ b/src/components/AddTrackerDialog.tsx
@@ -239,6 +239,7 @@ function AddTrackerDialog({
   const [iptCookies, setIptCookies] = useState("")
   const [tlUsername, setTlUsername] = useState("")
   const [tlPassword, setTlPassword] = useState("")
+  const [tlAlt2FAToken, setTlAlt2FAToken] = useState("")
   const [qbtTag, setQbtTag] = useState("")
   const [mouseholeUrl, setMouseholeUrl] = useState("")
   const [color, setColor] = useState<string>(CHART_THEME.accent)
@@ -255,6 +256,12 @@ function AddTrackerDialog({
     setAvistazUsername("")
     setAvistazCookies("")
     setDcCookies("")
+    // Drive-by: the TorrentLeech fields were never cleared here, so a closed
+    // dialog kept the password in memory and re-showed it on reopen. Adding a
+    // third secret without fixing that would have made it worse.
+    setTlUsername("")
+    setTlPassword("")
+    setTlAlt2FAToken("")
     setQbtTag("")
     setMouseholeUrl("")
     setColor(CHART_THEME.accent)
@@ -395,9 +402,13 @@ function AddTrackerDialog({
         userAgent: navigator.userAgent,
       })
     } else if (isTorrentleech) {
+      const alt2FAToken = tlAlt2FAToken.trim()
       effectiveApiToken = JSON.stringify({
         username: tlUsername.trim(),
         password: tlPassword,
+        // Omitted entirely for accounts without 2FA, so their stored credential
+        // blob stays exactly the shape it has always been.
+        ...(alt2FAToken ? { alt2FAToken } : {}),
       })
     }
 
@@ -661,6 +672,23 @@ function AddTrackerDialog({
               />
               <InfoTip
                 content="TorrentLeech has no API, so stats are read by logging in on your behalf. Your password is encrypted at rest with the same key as every other tracker credential."
+                size="sm"
+                docs={DOCS.ADDING_A_TRACKER}
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Input
+                label="Alt 2FA Token (optional)"
+                name="tracker-tl-alt2fa"
+                type="password"
+                autoComplete="off"
+                data-1p-ignore
+                value={tlAlt2FAToken}
+                onChange={(e) => setTlAlt2FAToken(e.target.value)}
+                placeholder="Only if 2FA is enabled on your account"
+              />
+              <InfoTip
+                content="Required only if your TorrentLeech account has 2FA enabled. Find it at Site Profile => Alt 2FA Token. It is a static token, not a rotating 6-digit code."
                 size="sm"
                 docs={DOCS.ADDING_A_TRACKER}
               />

--- a/src/components/TrackerSettingsSheet.tsx
+++ b/src/components/TrackerSettingsSheet.tsx
@@ -124,6 +124,7 @@ function TrackerSettingsSheet({ open, tracker, onClose, onUpdated }: TrackerSett
   const [editIptCookies, setEditIptCookies] = useState("")
   const [editTlUsername, setEditTlUsername] = useState("")
   const [editTlPassword, setEditTlPassword] = useState("")
+  const [editTlAlt2FAToken, setEditTlAlt2FAToken] = useState("")
 
   const [errors, setErrors] = useState<Record<string, string>>({})
   const [saving, setSaving] = useState(false)
@@ -216,9 +217,11 @@ function TrackerSettingsSheet({ open, tracker, onClose, onUpdated }: TrackerSett
         userAgent: navigator.userAgent,
       })
     } else if (changingKey && tracker.platformType === "torrentleech") {
+      const alt2FAToken = editTlAlt2FAToken.trim()
       trimmedToken = JSON.stringify({
         username: editTlUsername.trim(),
         password: editTlPassword,
+        ...(alt2FAToken ? { alt2FAToken } : {}),
       })
     } else if (changingKey && tracker.platformType === "digitalcore") {
       const trimmed = editDcCookies.trim()
@@ -494,6 +497,16 @@ function TrackerSettingsSheet({ open, tracker, onClose, onUpdated }: TrackerSett
                   value={editTlPassword}
                   onChange={(e) => setEditTlPassword(e.target.value)}
                 />
+                <Input
+                  label="Alt 2FA Token (optional)"
+                  name="edit-tl-alt2fa"
+                  type="password"
+                  autoComplete="off"
+                  data-1p-ignore
+                  value={editTlAlt2FAToken}
+                  onChange={(e) => setEditTlAlt2FAToken(e.target.value)}
+                  placeholder="Only if 2FA is enabled on your account"
+                />
                 <Notice message={errors.apiToken} />
                 <Button
                   variant="minimal"
@@ -502,6 +515,7 @@ function TrackerSettingsSheet({ open, tracker, onClose, onUpdated }: TrackerSett
                   className="self-start"
                   onClick={() => {
                     setChangingKey(false)
+                    setEditTlAlt2FAToken("")
                     setEditTlUsername("")
                     setEditTlPassword("")
                     setErrors({})

--- a/src/lib/adapters/torrentleech.test.ts
+++ b/src/lib/adapters/torrentleech.test.ts
@@ -10,21 +10,72 @@ vi.mock("@/lib/tunnel", async (importOriginal) => ({
   proxyFetch: vi.fn(),
 }))
 
-const PROFILE_HTML = `
-<div class="profile-uploaded">
-  <i class="fa fa-arrow-circle-o-up"></i> uploaded:
-  <span class="profile-info-details profile-uploaded-details">10.5 GB</span>
-</div>
-<div class="profile-downloaded">
-  <i class="fa fa-arrow-circle-o-down"></i> downloaded:
-  <span class="profile-info-details profile-downloaded-details">5.25 GB</span>
-</div>
-<div class="profile-ratio">
-  <i class="fa fa-percent"></i> ratio:
-  <span class="profile-info-details profile-ratio-details">2.000</span>
-</div>`
+// Markup copied from a live TorrentLeech profile page, with the account's own
+// figures replaced. The structure is verbatim, and it has to be: the previous
+// fixture was written from the same assumption as the parser (a
+// `profile-downloaded-details` class that the site does not emit), so the tests
+// agreed with the bug instead of catching it.
+//
+// The pieces that matter, and why each is here:
+//   - the "Classic TL" nav link, present on every page, which the old class
+//     regex matched before ever reaching the real class
+//   - the top bar, the only source of seeding/leeching counts and hit-and-runs,
+//     where the count follows the size in parentheses
+//   - the asymmetric uploaded/downloaded spans
+const NAV_HTML = `
+<ul class="nav">
+  <li><a href="http://wiki.torrentleech.org">Wiki</a></li>
+  <li><a href="http://classic.torrentleech.org">Classic TL</a></li>
+  <li><a href="http://v4.torrentleech.org">V4 TL</a></li>
+</ul>`
 
-const FULL_PROFILE_PAGE = `<!doctype html><html><head></head><body>${PROFILE_HTML}</body></html>`
+const TOP_BAR_HTML = `
+<span class="menu-info">
+  <div title="Uploaded (Seeding)" class="div-menu-item">
+    <i class="fa fa-arrow-circle-o-up"></i> <span class="link">10.5 GB</span> (12)
+  </div>
+  <div title="Downloaded (Leeching)" class="div-menu-item">
+    <i class="fa fa-arrow-circle-o-down"></i> <span class="link">5.25 GB</span> (3)
+  </div>
+  <div title="Buffer" class="div-menu-item"><i class="fa fa-refresh"></i> 5.25 GB</div>
+  <div title="Ratio" class="div-menu-item"><i class="fa fa-percent"></i> 2.000</div>
+  <div title="Hit and Run" class="div-menu-item">
+    <span class="link"><i class="fa fa-ban"></i>  2</span>
+  </div>
+</span>
+<span class="menu-info">
+  <div class="div-menu-item"><span class="link">TL Points: <span class="total-TL-points">2,750.50</span></span></div>
+  <div class="div-menu-item">Slots: <span>&infin;</span></div>
+</span>`
+
+// Note the asymmetry, which is the site's and not a typo: the uploaded span
+// carries `profile-uploaded-details`, the downloaded span carries no
+// counterpart class.
+const PROFILE_HTML = `
+<div class="profile-details">
+  <div class="profile-username profile-details-item">testuser</div>
+  <div class="label label-success label-user-class profile-details-item">
+    Registered
+  </div>
+</div>
+<div class="profile-info">
+  <div class="profile-uploaded">
+    <i class="fa fa-arrow-circle-o-up"></i> uploaded:<span class="profile-info-details profile-uploaded-details">10.5 GB</span>
+  </div>
+  <div class="profile-downloaded">
+    <i class="fa fa-arrow-circle-o-down"></i> downloaded: <span class="profile-info-details">5.25 GB</span>
+  </div>
+  <div class="profile-ratio">
+    <i class="fa fa-percent"></i> ratio:<span class="profile-info-details profile-ratio-details">2.000</span>
+  </div>
+  <div class="profile-slots"><i class="fa fa-braille"></i> slots:<span class="profile-info-details">&infin;</span></div>
+</div>
+<table>
+  <tr><td>Username</td><td>testuser</td></tr>
+  <tr><td>Class</td><td>Registered</td></tr>
+</table>`
+
+const FULL_PROFILE_PAGE = `<!doctype html><html><head></head><body>${NAV_HTML}${TOP_BAR_HTML}${PROFILE_HTML}</body></html>`
 
 function setCookieResponse(cookies: string[], overrides: Partial<Response> = {}): Response {
   return {
@@ -46,10 +97,82 @@ describe("parseTlProfile", () => {
     expect(stats.bufferBytes).toBe(10_500_000_000n - 5_250_000_000n)
   })
 
+  it("reads downloaded bytes from a span with no profile-downloaded-details class", () => {
+    // The regression guard. If this ever reads 0 again, ratio becomes Infinity
+    // and every torrent on the tracker looks satisfied.
+    const stats = parseTlProfile(FULL_PROFILE_PAGE, "testuser")
+    expect(stats.downloadedBytes).toBeGreaterThan(0n)
+    expect(stats.ratio).not.toBe(Infinity)
+  })
+
+  it("still prefers profile-downloaded-details when the markup is symmetric", () => {
+    const symmetric = FULL_PROFILE_PAGE.replace(
+      '<span class="profile-info-details">5.25 GB</span>',
+      '<span class="profile-info-details profile-downloaded-details">1.25 GB</span>'
+    )
+    expect(parseTlProfile(symmetric, "testuser").downloadedBytes).toBe(1_250_000_000n)
+  })
+
+  it("reads the user class from the badge, not the Classic TL nav link", () => {
+    const stats = parseTlProfile(FULL_PROFILE_PAGE, "testuser")
+    expect(stats.group).toBe("Registered")
+  })
+
+  it("falls back to the Class table row when the badge is absent", () => {
+    const noBadge = FULL_PROFILE_PAGE.replace("label-user-class", "label-something-else")
+    expect(parseTlProfile(noBadge, "testuser").group).toBe("Registered")
+  })
+
+  it("defaults the class to User when the page carries neither", () => {
+    const noClass = `<!doctype html><html><body>${NAV_HTML}${PROFILE_HTML.replace(
+      "label-user-class",
+      "x"
+    ).replace("<td>Class</td>", "<td>Rank</td>")}</body></html>`
+    expect(parseTlProfile(noClass, "testuser").group).toBe("User")
+  })
+
+  it("counts torrents from the parenthesised figure, not the size beside it", () => {
+    // "10.5 GB (12)" — the first number in that cell is 10, which is a byte
+    // total masquerading as a torrent count.
+    const stats = parseTlProfile(FULL_PROFILE_PAGE, "testuser")
+    expect(stats.seedingCount).toBe(12)
+    expect(stats.leechingCount).toBe(3)
+  })
+
+  it("reports hit and runs from the top bar", () => {
+    expect(parseTlProfile(FULL_PROFILE_PAGE, "testuser").hitAndRuns).toBe(2)
+  })
+
+  it("reports zero hit and runs as 0, not null", () => {
+    const clean = FULL_PROFILE_PAGE.replace('<i class="fa fa-ban"></i>  2', '<i class="fa fa-ban"></i>  0')
+    expect(parseTlProfile(clean, "testuser").hitAndRuns).toBe(0)
+  })
+
+  it("reports hit and runs as null when the top bar has no such cell", () => {
+    const noCell = FULL_PROFILE_PAGE.replace('title="Hit and Run"', 'title="Something Else"')
+    expect(parseTlProfile(noCell, "testuser").hitAndRuns).toBeNull()
+  })
+
+  it("reads TL Points from the total-TL-points span", () => {
+    expect(parseTlProfile(FULL_PROFILE_PAGE, "testuser").seedbonus).toBeCloseTo(2750.5)
+  })
+
+  it("falls back to the TL Points label when the span class is absent", () => {
+    const noSpan = FULL_PROFILE_PAGE.replace("total-TL-points", "tl-points-renamed")
+    expect(parseTlProfile(noSpan, "testuser").seedbonus).toBeCloseTo(2750.5)
+  })
+
+  it("reports counts as 0 when the top bar is missing entirely", () => {
+    const noTopBar = `<!doctype html><html><body>${PROFILE_HTML}</body></html>`
+    const stats = parseTlProfile(noTopBar, "testuser")
+    expect(stats.seedingCount).toBe(0)
+    expect(stats.leechingCount).toBe(0)
+  })
+
   it("reports an infinite ratio (∞) as Infinity", () => {
     const infPage = `<!doctype html><html><body>
       <div class="profile-uploaded"><span class="profile-info-details profile-uploaded-details">10.5 GB</span></div>
-      <div class="profile-downloaded"><span class="profile-info-details profile-downloaded-details">0 B</span></div>
+      <div class="profile-downloaded"><span class="profile-info-details">0 B</span></div>
       <div class="profile-ratio"><span class="profile-info-details profile-ratio-details">&infin;</span></div>
     </body></html>`
     const stats = parseTlProfile(infPage, "testuser")
@@ -59,7 +182,7 @@ describe("parseTlProfile", () => {
   it("derives Infinity for a zero-download account even with no ratio cell", () => {
     const noRatioCell = `<!doctype html><html><body>
       <div class="profile-uploaded"><span class="profile-info-details profile-uploaded-details">250 GB</span></div>
-      <div class="profile-downloaded"><span class="profile-info-details profile-downloaded-details">0 B</span></div>
+      <div class="profile-downloaded"><span class="profile-info-details">0 B</span></div>
     </body></html>`
     const stats = parseTlProfile(noRatioCell, "testuser")
     expect(stats.uploadedBytes).toBe(250_000_000_000n)

--- a/src/lib/adapters/torrentleech.test.ts
+++ b/src/lib/adapters/torrentleech.test.ts
@@ -3,6 +3,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { parseTlCredentials, parseTlProfile, TorrentleechAdapter } from "./torrentleech"
 
+// The proxy path is what these tests are checking is TAKEN, so proxyFetch is
+// mocked rather than exercised — tunnel.ts has its own coverage.
+vi.mock("@/lib/tunnel", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/tunnel")>()),
+  proxyFetch: vi.fn(),
+}))
+
 const PROFILE_HTML = `
 <div class="profile-uploaded">
   <i class="fa fa-arrow-circle-o-up"></i> uploaded:
@@ -136,8 +143,10 @@ describe("TorrentleechAdapter.fetchStats", () => {
   const adapter = new TorrentleechAdapter()
   const validToken = JSON.stringify({ username: "testuser", password: "hunter2" })
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.restoreAllMocks()
+    const { proxyFetch } = await import("@/lib/tunnel")
+    vi.mocked(proxyFetch).mockReset()
     // The adapter caches login sessions on globalThis so it doesn't
     // re-authenticate every poll. Clear it so each test starts cold.
     ;(globalThis as { __tlSessionCache?: Map<string, string> }).__tlSessionCache?.clear()
@@ -309,6 +318,86 @@ describe("TorrentleechAdapter.fetchStats", () => {
 
     const stats = await adapter.fetchStats("https://www.torrentleech.org", validToken, "")
     expect(stats.username).toBe("testuser")
+  })
+
+  it("sends the login POST through the proxy when one is configured", async () => {
+    const { proxyFetch } = await import("@/lib/tunnel")
+    const proxySpy = vi.mocked(proxyFetch)
+    proxySpy.mockResolvedValueOnce({
+      ok: true,
+      status: 302,
+      statusText: "Found",
+      headers: { "set-cookie": ["tluid=abc123; Path=/"] },
+      json: async () => ({}),
+      text: async () => "",
+      buffer: async () => Buffer.from(""),
+    })
+    // The profile GET was already proxied before this change; the login POST
+    // was the one request that was not.
+    proxySpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      json: async () => ({}),
+      text: async () => FULL_PROFILE_PAGE,
+      buffer: async () => Buffer.from(FULL_PROFILE_PAGE),
+    })
+    const fetchSpy = vi.spyOn(global, "fetch")
+
+    const agent = {} as never
+    const stats = await adapter.fetchStats("https://www.torrentleech.org", validToken, "", {
+      proxyAgent: agent,
+    })
+
+    expect(stats.username).toBe("testuser")
+    // The whole point: the request carrying the password went through the
+    // proxy, and nothing went out the direct path at all.
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(proxySpy).toHaveBeenCalledTimes(2)
+
+    const [url, passedAgent, opts] = proxySpy.mock.calls[0]
+    expect(url).toBe("https://www.torrentleech.org/user/account/login/")
+    expect(passedAgent).toBe(agent)
+    expect(opts?.method).toBe("POST")
+    expect(new URLSearchParams(opts?.body ?? "").get("username")).toBe("testuser")
+    expect(proxySpy.mock.calls[1][0]).toContain("/profile/testuser")
+  })
+
+  it("still uses a direct fetch for the login when no proxy is configured", async () => {
+    const { proxyFetch } = await import("@/lib/tunnel")
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(setCookieResponse(["tluid=abc123; Path=/"]))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => FULL_PROFILE_PAGE,
+      } as Response)
+
+    await adapter.fetchStats("https://www.torrentleech.org", validToken, "")
+
+    expect(vi.mocked(proxyFetch)).not.toHaveBeenCalled()
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it("reads the 2FA hint from the proxied response body too", async () => {
+    const { proxyFetch } = await import("@/lib/tunnel")
+    vi.mocked(proxyFetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      json: async () => ({}),
+      text: async () => `<div class="login-container"><h2>One Time Password</h2></div>`,
+      buffer: async () => Buffer.from(""),
+    })
+
+    await expect(
+      adapter.fetchStats("https://www.torrentleech.org", validToken, "", {
+        proxyAgent: {} as never,
+      })
+    ).rejects.toThrow("Alt 2FA Token")
   })
 
   it("detects a Cloudflare challenge on the profile page", async () => {

--- a/src/lib/adapters/torrentleech.test.ts
+++ b/src/lib/adapters/torrentleech.test.ts
@@ -257,6 +257,60 @@ describe("TorrentleechAdapter.fetchStats", () => {
     ).rejects.toThrow("Invalid TorrentLeech credentials or Alt 2FA Token")
   })
 
+  it("rejects a 200 login that still set tluid — TL does this on a REFUSED login", async () => {
+    // Measured against the live site: a rejected login answers 200 with the
+    // login page and still sets tluid/tlpass/member_id/pass_hash/session_id.
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      setCookieResponse(["tluid=abc123; Path=/", "tlpass=xyz; Path=/"], {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        text: async () => `<form name="login-form"><a href="/user/account/login">in</a></form>`,
+      } as Partial<Response>)
+    )
+
+    await expect(
+      adapter.fetchStats("https://www.torrentleech.org", validToken, "")
+    ).rejects.toThrow("Invalid TorrentLeech credentials")
+  })
+
+  it("names 2FA when a cookie-bearing 200 login shows the One Time Password page", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      setCookieResponse(["tluid=abc123; Path=/"], {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        text: async () => `<div class="login-container"><h2>One Time Password</h2></div>`,
+      } as Partial<Response>)
+    )
+
+    await expect(
+      adapter.fetchStats("https://www.torrentleech.org", validToken, "")
+    ).rejects.toThrow("Alt 2FA Token")
+  })
+
+  it("still accepts a 200 login that does not look like the login page", async () => {
+    // Guards the fallback: the redirect is the signal today, but a 200 with a
+    // real page and a session cookie must not start failing.
+    vi.spyOn(global, "fetch")
+      .mockResolvedValueOnce(
+        setCookieResponse(["tluid=abc123; Path=/"], {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () => `<html><body>Welcome back</body></html>`,
+        } as Partial<Response>)
+      )
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => FULL_PROFILE_PAGE,
+      } as Response)
+
+    const stats = await adapter.fetchStats("https://www.torrentleech.org", validToken, "")
+    expect(stats.username).toBe("testuser")
+  })
+
   it("detects a Cloudflare challenge on the profile page", async () => {
     vi.spyOn(global, "fetch")
       .mockResolvedValueOnce(setCookieResponse(["tluid=abc123; Path=/"]))

--- a/src/lib/adapters/torrentleech.test.ts
+++ b/src/lib/adapters/torrentleech.test.ts
@@ -97,6 +97,39 @@ describe("parseTlCredentials", () => {
   it("throws on non-JSON string", () => {
     expect(() => parseTlCredentials("not-json")).toThrow()
   })
+
+  it("omits alt2FAToken entirely when the account has no 2FA", () => {
+    const json = JSON.stringify({ username: "testuser", password: "hunter2" })
+    expect(parseTlCredentials(json)).not.toHaveProperty("alt2FAToken")
+  })
+
+  it("parses the Alt 2FA Token when present", () => {
+    const json = JSON.stringify({
+      username: "testuser",
+      password: "hunter2",
+      alt2FAToken: "  abc123def456  ",
+    })
+    expect(parseTlCredentials(json).alt2FAToken).toBe("abc123def456")
+  })
+
+  it("accepts the all-lowercase alt2fatoken spelling other clients store", () => {
+    const json = JSON.stringify({
+      username: "testuser",
+      password: "hunter2",
+      alt2fatoken: "abc123def456",
+    })
+    expect(parseTlCredentials(json).alt2FAToken).toBe("abc123def456")
+  })
+
+  it("treats a blank Alt 2FA Token as absent rather than sending an empty field", () => {
+    const json = JSON.stringify({ username: "u", password: "p", alt2FAToken: "   " })
+    expect(parseTlCredentials(json)).not.toHaveProperty("alt2FAToken")
+  })
+
+  it("throws when the Alt 2FA Token is not a string", () => {
+    const json = JSON.stringify({ username: "u", password: "p", alt2FAToken: 123456 })
+    expect(() => parseTlCredentials(json)).toThrow("alt2FAToken must be a string")
+  })
 })
 
 describe("TorrentleechAdapter.fetchStats", () => {
@@ -144,6 +177,84 @@ describe("TorrentleechAdapter.fetchStats", () => {
     await expect(
       adapter.fetchStats("https://www.torrentleech.org", validToken, "")
     ).rejects.toThrow("Invalid TorrentLeech credentials")
+  })
+
+  it("posts alt2FAToken as a third login field when the account has 2FA", async () => {
+    const tokenCreds = JSON.stringify({
+      username: "testuser",
+      password: "hunter2",
+      alt2FAToken: "abc123def456",
+    })
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(setCookieResponse(["tluid=abc123; Path=/"]))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => FULL_PROFILE_PAGE,
+      } as Response)
+
+    await adapter.fetchStats("https://www.torrentleech.org", tokenCreds, "")
+
+    const body = fetchSpy.mock.calls[0][1]?.body as string
+    const form = new URLSearchParams(body)
+    // The field name is TorrentLeech's own spelling, not ours — the login form
+    // reads `alt2FAToken` and silently ignores anything else.
+    expect(form.get("alt2FAToken")).toBe("abc123def456")
+    expect(form.get("username")).toBe("testuser")
+    expect(form.get("password")).toBe("hunter2")
+  })
+
+  it("does not send an alt2FAToken field at all for accounts without 2FA", async () => {
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(setCookieResponse(["tluid=abc123; Path=/"]))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => FULL_PROFILE_PAGE,
+      } as Response)
+
+    await adapter.fetchStats("https://www.torrentleech.org", validToken, "")
+
+    const body = fetchSpy.mock.calls[0][1]?.body as string
+    expect(new URLSearchParams(body).has("alt2FAToken")).toBe(false)
+  })
+
+  it("names 2FA as the cause when the login page asks for a One Time Password", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      setCookieResponse([], {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        text: async () =>
+          `<div class="login-container"><h2>One Time Password</h2></div>`,
+      } as Partial<Response>)
+    )
+
+    await expect(
+      adapter.fetchStats("https://www.torrentleech.org", validToken, "")
+    ).rejects.toThrow("Alt 2FA Token")
+  })
+
+  it("blames the token too when a 2FA login is refused", async () => {
+    const tokenCreds = JSON.stringify({
+      username: "testuser",
+      password: "hunter2",
+      alt2FAToken: "wrong-token",
+    })
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      setCookieResponse([], {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        text: async () => `<p class="text-danger">Invalid login</p>`,
+      } as Partial<Response>)
+    )
+
+    await expect(
+      adapter.fetchStats("https://www.torrentleech.org", tokenCreds, "")
+    ).rejects.toThrow("Invalid TorrentLeech credentials or Alt 2FA Token")
   })
 
   it("detects a Cloudflare challenge on the profile page", async () => {

--- a/src/lib/adapters/torrentleech.ts
+++ b/src/lib/adapters/torrentleech.ts
@@ -19,6 +19,15 @@ import type { DebugApiCall, FetchOptions, TrackerAdapter, TrackerStats } from ".
 export interface TlCredentials {
   username: string
   password: string
+  /**
+   * TorrentLeech's "Alt 2FA Token" (Site Profile => Alt 2FA Token), required
+   * only when the account has 2FA enabled.
+   *
+   * It is NOT a TOTP secret and nothing here computes a one-time code. The site
+   * issues a static token for exactly this case, and its login form takes it as
+   * a third input alongside username and password.
+   */
+  alt2FAToken?: string
 }
 
 export function parseTlCredentials(apiToken: string): TlCredentials {
@@ -27,7 +36,25 @@ export function parseTlCredentials(apiToken: string): TlCredentials {
     "password",
   ] as const)
 
-  return { username: username.trim(), password }
+  // The optional third field is read separately: parseCredentialJson asserts
+  // every field it is given is present, and this one legitimately is not for
+  // accounts without 2FA. Re-parsing is safe — the call above has already
+  // proven the blob is valid JSON.
+  const raw = JSON.parse(apiToken) as Record<string, unknown>
+  // `alt2FAToken` is the site's own spelling; `alt2fatoken` is accepted too
+  // because that is the key other clients store it under, and being strict
+  // about the capitalisation of a pasted token helps nobody.
+  const token = raw.alt2FAToken ?? raw.alt2fatoken
+  if (token !== undefined && typeof token !== "string") {
+    throw new Error("TorrentLeech credentials: alt2FAToken must be a string")
+  }
+  const alt2FAToken = typeof token === "string" ? token.trim() : ""
+
+  return {
+    username: username.trim(),
+    password,
+    ...(alt2FAToken ? { alt2FAToken } : {}),
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -60,12 +87,12 @@ function sessionKey(baseUrl: string, username: string): string {
   return `${baseUrl}|${username}`
 }
 
-async function getTlSession(baseUrl: string, username: string, password: string): Promise<string> {
-  const key = sessionKey(baseUrl, username)
+async function getTlSession(baseUrl: string, creds: TlCredentials): Promise<string> {
+  const key = sessionKey(baseUrl, creds.username)
   const cached = tlSessionCache.get(key)
   if (cached) return cached
 
-  const cookies = await login(baseUrl, username, password)
+  const cookies = await login(baseUrl, creds)
   tlSessionCache.set(key, cookies)
   return cookies
 }
@@ -74,9 +101,16 @@ function invalidateTlSession(baseUrl: string, username: string): void {
   tlSessionCache.delete(sessionKey(baseUrl, username))
 }
 
-async function login(baseUrl: string, username: string, password: string): Promise<string> {
+async function login(baseUrl: string, creds: TlCredentials): Promise<string> {
   const loginUrl = `${baseUrl}/user/account/login/`
-  const body = new URLSearchParams({ username, password }).toString()
+  const form: Record<string, string> = {
+    username: creds.username,
+    password: creds.password,
+  }
+  // Only sent when the account actually has 2FA. Omitting the field entirely
+  // for everyone else keeps the request byte-identical to what worked before.
+  if (creds.alt2FAToken) form.alt2FAToken = creds.alt2FAToken
+  const body = new URLSearchParams(form).toString()
   const headers: Record<string, string> = {
     "Content-Type": "application/x-www-form-urlencoded",
     Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
@@ -102,6 +136,25 @@ async function login(baseUrl: string, username: string, password: string): Promi
 
   const cookieString = cookiePairs.join("; ")
   if (!cookieString.includes("tluid=")) {
+    // No session cookie means the login was refused. Read the body to say WHY:
+    // a 2FA-enabled account with no token gets the same empty-cookie response
+    // as a wrong password, and "Invalid TorrentLeech credentials" sends people
+    // to re-check a password that was never the problem.
+    let html = ""
+    try {
+      html = await response.text()
+    } catch {
+      // Body already consumed or connection dropped — fall through to the
+      // generic message rather than masking the login failure with a read error.
+    }
+    if (/One Time Password/i.test(html)) {
+      throw new Error(
+        "TorrentLeech requires 2FA — add your Alt 2FA Token (Site Profile => Alt 2FA Token) to this tracker's credentials"
+      )
+    }
+    if (creds.alt2FAToken) {
+      throw new Error("Invalid TorrentLeech credentials or Alt 2FA Token")
+    }
     throw new Error("Invalid TorrentLeech credentials")
   }
 
@@ -222,7 +275,7 @@ export class TorrentleechAdapter implements TrackerAdapter {
     const creds = parseTlCredentials(apiToken)
     const profileUrl = `${baseUrl}/profile/${encodeURIComponent(creds.username)}`
 
-    let cookies = await getTlSession(baseUrl, creds.username, creds.password)
+    let cookies = await getTlSession(baseUrl, creds)
     let html: string
     try {
       html = await fetchHtml(profileUrl, cookies, options?.proxyAgent)
@@ -231,7 +284,7 @@ export class TorrentleechAdapter implements TrackerAdapter {
       // the login page. Drop it and authenticate once more before giving up.
       if (!(err instanceof Error) || !err.message.startsWith("Session expired")) throw err
       invalidateTlSession(baseUrl, creds.username)
-      cookies = await getTlSession(baseUrl, creds.username, creds.password)
+      cookies = await getTlSession(baseUrl, creds)
       html = await fetchHtml(profileUrl, cookies, options?.proxyAgent)
     }
     return parseTlProfile(html, creds.username)
@@ -248,7 +301,7 @@ export class TorrentleechAdapter implements TrackerAdapter {
     const endpoint = `/profile/${creds.username}`
 
     try {
-      const cookies = await getTlSession(baseUrl, creds.username, creds.password)
+      const cookies = await getTlSession(baseUrl, creds)
       const profileUrl = `${baseUrl}${endpoint}`
       const html = await fetchHtml(profileUrl, cookies, options?.proxyAgent)
       const stats = parseTlProfile(html, creds.username)

--- a/src/lib/adapters/torrentleech.ts
+++ b/src/lib/adapters/torrentleech.ts
@@ -61,6 +61,13 @@ export function parseTlCredentials(apiToken: string): TlCredentials {
 // Login flow
 // ---------------------------------------------------------------------------
 
+/** Every status that carries a Location, matching html-fetch's own set. */
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308])
+
+function isRedirect(status: number): boolean {
+  return REDIRECT_STATUSES.has(status)
+}
+
 /**
  * Logs in and returns the Cookie header string built from Set-Cookie response headers.
  * tunnel.ts's proxyFetch is GET-only with no body support, so login always goes
@@ -135,18 +142,40 @@ async function login(baseUrl: string, creds: TlCredentials): Promise<string> {
     .filter((pair): pair is string => Boolean(pair))
 
   const cookieString = cookiePairs.join("; ")
-  if (!cookieString.includes("tluid=")) {
-    // No session cookie means the login was refused. Read the body to say WHY:
-    // a 2FA-enabled account with no token gets the same empty-cookie response
-    // as a wrong password, and "Invalid TorrentLeech credentials" sends people
-    // to re-check a password that was never the problem.
+
+  // A tluid cookie is NOT proof of authentication. TorrentLeech answers a
+  // REJECTED login with 200 and the login page, and still sets tluid, tlpass,
+  // member_id, pass_hash and session_id. Trusting the cookie means caching a
+  // session that was never signed in, and every later page fetch then comes
+  // back as the login page — reported as "Session expired", which sends people
+  // off to refresh a session that never existed. A real login answers 302.
+  //
+  // The body is only inspected when the response was not a redirect: a 302
+  // carries no body, and a 200 that does NOT look like the login page is still
+  // accepted, so a future flow that returns 200 on success would not regress.
+  const authenticated = cookieString.includes("tluid=") && isRedirect(response.status)
+  if (!authenticated) {
     let html = ""
-    try {
-      html = await response.text()
-    } catch {
-      // Body already consumed or connection dropped — fall through to the
-      // generic message rather than masking the login failure with a read error.
+    if (!isRedirect(response.status)) {
+      try {
+        html = await response.text()
+      } catch {
+        // Body already consumed or connection dropped — fall through to the
+        // generic message rather than masking the login failure with a read error.
+      }
     }
+
+    const looksLikeLoginPage =
+      /One Time Password/i.test(html) ||
+      /name="login-form"/i.test(html) ||
+      html.includes("/user/account/login")
+
+    // Reject only on POSITIVE evidence of a refusal. A 200 whose body could not
+    // be read, or that does not look like the login page, keeps the old
+    // behaviour of trusting the cookie — this tightens a check that was wrong,
+    // without inventing a new way to fail.
+    if (cookieString.includes("tluid=") && !looksLikeLoginPage) return cookieString
+
     if (/One Time Password/i.test(html)) {
       throw new Error(
         "TorrentLeech requires 2FA — add your Alt 2FA Token (Site Profile => Alt 2FA Token) to this tracker's credentials"

--- a/src/lib/adapters/torrentleech.ts
+++ b/src/lib/adapters/torrentleech.ts
@@ -1,7 +1,8 @@
 // src/lib/adapters/torrentleech.ts
 //
 // Functions: parseTlCredentials, sessionKey, getTlSession, invalidateTlSession, login,
-//            textAfterNode, parseTlProfile, fetchHtml, TorrentleechAdapter
+//            textAfterNode, firstText, topBarCell, parenCount, trailingCount,
+//            parseTlProfile, fetchHtml, TorrentleechAdapter
 
 import { type HTMLElement as ParsedElement, parse as parseHtml } from "node-html-parser"
 import { computeBufferBytes, computeRatio } from "@/lib/data-transforms"
@@ -230,6 +231,48 @@ function textAfterNode(root: ParsedElement, selector: string): string {
   return root.querySelector(selector)?.textContent?.trim() ?? ""
 }
 
+/** First selector in the list that yields non-empty text. */
+function firstText(root: ParsedElement, selectors: string[]): string {
+  for (const selector of selectors) {
+    const text = textAfterNode(root, selector)
+    if (text) return text
+  }
+  return ""
+}
+
+/**
+ * Reads the top-bar widget TorrentLeech renders on every page. Its cells are
+ * identified only by a `title` attribute ("Uploaded (Seeding)", "Hit and Run"),
+ * which is the sole place some numbers appear at all.
+ */
+function topBarCell(doc: ParsedElement, title: RegExp): string {
+  for (const item of doc.querySelectorAll(".div-menu-item")) {
+    if (title.test(item.getAttribute("title") ?? "")) return item.textContent?.trim() ?? ""
+  }
+  return ""
+}
+
+/**
+ * The active-torrent count in a top-bar cell, which reads "10.5 GB (12)": a
+ * size followed by the count in parentheses.
+ *
+ * Taking the FIRST number instead reads the size's leading digits — "10.5 GB
+ * (12)" yields 10, a plausible-looking torrent count that is really a byte
+ * total. Anchor on the parentheses, and report nothing rather than a guess when
+ * they are absent.
+ */
+function parenCount(text: string): number {
+  const match = text.match(/\((\d[\d,]*)\)/)
+  return match ? parseInt(match[1].replace(/,/g, ""), 10) : 0
+}
+
+/** The last standalone integer in a cell, for cells that carry only a count. */
+function trailingCount(text: string): number | null {
+  const matches = text.match(/\d[\d,]*/g)
+  if (!matches) return null
+  return parseInt(matches[matches.length - 1].replace(/,/g, ""), 10)
+}
+
 export function parseTlProfile(html: string, username: string): TrackerStats {
   if (html.includes("/user/account/login")) {
     throw new Error("Session expired — TorrentLeech cookies need to be refreshed")
@@ -245,8 +288,24 @@ export function parseTlProfile(html: string, username: string): TrackerStats {
 
   const doc = parseHtml(html)
 
-  const uploadedText = textAfterNode(doc, ".profile-uploaded-details")
-  const downloadedText = textAfterNode(doc, ".profile-downloaded-details")
+  // Only the uploaded figure carries a `profile-uploaded-details` class. Its
+  // downloaded counterpart is marked up as a bare `profile-info-details` span
+  // inside `.profile-downloaded` — there is no `profile-downloaded-details`
+  // anywhere on the page, so selecting it matched nothing and every account
+  // parsed as having downloaded zero bytes. That is not a cosmetic miss: it
+  // makes `computeRatio` return Infinity and `computeBufferBytes` return the
+  // full upload total, so an account is reported as unconditionally healthy.
+  //
+  // Both are read through the parent container, with the details class kept
+  // first in case TorrentLeech ever makes the markup symmetric.
+  const uploadedText = firstText(doc, [
+    ".profile-uploaded-details",
+    ".profile-uploaded .profile-info-details",
+  ])
+  const downloadedText = firstText(doc, [
+    ".profile-downloaded-details",
+    ".profile-downloaded .profile-info-details",
+  ])
 
   if (!uploadedText && !downloadedText) {
     throw new Error(
@@ -257,28 +316,44 @@ export function parseTlProfile(html: string, username: string): TrackerStats {
   const uploadedBytes = uploadedText ? parseBytes(uploadedText) : 0n
   const downloadedBytes = downloadedText ? parseBytes(downloadedText) : 0n
 
-  // Active seeding/leeching counts appear as header menu items with tooltip
-  // titles ("Uploaded (Seeding)" / "Downloaded (Leeching)").
-  let seedingCount = 0
-  let leechingCount = 0
-  for (const item of doc.querySelectorAll(".div-menu-item")) {
-    const title = item.getAttribute("title") ?? ""
-    const numMatch = item.textContent?.match(/[\d,]+/)
-    const count = numMatch ? parseInt(numMatch[0].replace(/,/g, ""), 10) : 0
-    if (/seeding/i.test(title)) seedingCount = count
-    else if (/leeching/i.test(title)) leechingCount = count
+  // Active seeding/leeching counts appear only in the top bar, alongside the
+  // size totals they are parenthesised after.
+  const seedingCount = parenCount(topBarCell(doc, /seeding/i))
+  const leechingCount = parenCount(topBarCell(doc, /leeching/i))
+
+  // Hit and runs have their own top-bar cell. It was previously reported as
+  // null — "this tracker does not expose it" — while the page showed it all
+  // along, which is the one number this whole tool exists to surface.
+  const hitAndRuns = trailingCount(topBarCell(doc, /hit and run/i))
+
+  // TL Points. Read from the span that holds the figure; the "TL Points:" label
+  // is a fallback for layouts that do not carry the class.
+  let seedbonus = 0
+  const pointsText = textAfterNode(doc, ".total-TL-points")
+  if (pointsText) {
+    seedbonus = parseFloat(pointsText.replace(/,/g, ""))
+  } else {
+    const pointsMatch = (doc.textContent ?? "").match(/TL Points:\s*([\d,.]+)/i)
+    if (pointsMatch) seedbonus = parseFloat(pointsMatch[1].replace(/,/g, ""))
   }
 
-  // TL Points, often shown near a "TL Points:" label.
-  let seedbonus = 0
-  const bodyText = doc.textContent ?? ""
-  const pointsMatch = bodyText.match(/TL Points:\s*([\d,.]+)/i)
-  if (pointsMatch) seedbonus = parseFloat(pointsMatch[1].replace(/,/g, ""))
-
-  // Class badge, if present in a profile field/label pair.
-  let group = "User"
-  const classMatch = bodyText.match(/Class:?\s*\n?\s*([A-Za-z][A-Za-z ]*)/)
-  if (classMatch) group = classMatch[1].trim()
+  // User class, from the badge beside the avatar, falling back to the "Class"
+  // row of the profile table.
+  //
+  // It used to be matched with /Class:?\s*\n?\s*([A-Za-z][A-Za-z ]*)/ against
+  // the whole document's text. Every TorrentLeech page carries a nav link
+  // reading "Classic TL", and that link comes first, so the pattern captured
+  // "ic TL" for every account on the site.
+  let group = textAfterNode(doc, ".label-user-class")
+  if (!group) {
+    for (const cell of doc.querySelectorAll("td")) {
+      if (cell.textContent?.trim() === "Class") {
+        group = cell.nextElementSibling?.textContent?.trim() ?? ""
+        break
+      }
+    }
+  }
+  if (!group) group = "User"
 
   return {
     username,
@@ -293,7 +368,7 @@ export function parseTlProfile(html: string, username: string): TrackerStats {
     seedingCount,
     leechingCount,
     seedbonus,
-    hitAndRuns: null,
+    hitAndRuns,
     requiredRatio: null,
     warned: null,
     freeleechTokens: null,

--- a/src/lib/adapters/torrentleech.ts
+++ b/src/lib/adapters/torrentleech.ts
@@ -8,6 +8,7 @@ import { computeBufferBytes, computeRatio } from "@/lib/data-transforms"
 import { classifyFetchError } from "@/lib/error-utils"
 import { ADAPTER_FETCH_TIMEOUT_MS } from "@/lib/limits"
 import { parseBytes } from "@/lib/parser"
+import { proxyFetch } from "@/lib/tunnel"
 import { parseCredentialJson } from "./cookie-credentials"
 import { fetchTrackerHtml } from "./html-fetch"
 import type { DebugApiCall, FetchOptions, TrackerAdapter, TrackerStats } from "./types"
@@ -70,8 +71,11 @@ function isRedirect(status: number): boolean {
 
 /**
  * Logs in and returns the Cookie header string built from Set-Cookie response headers.
- * tunnel.ts's proxyFetch is GET-only with no body support, so login always goes
- * through a direct fetch — only the subsequent profile page fetch honors proxyAgent.
+ *
+ * Honors the configured proxy. It previously did not — the login POST always
+ * went out directly while only the profile GET was proxied, so a user who
+ * configured a proxy still leaked their real address to the tracker on every
+ * re-authentication, which is the one request that carries their password.
  */
 // ---------------------------------------------------------------------------
 // Session cache
@@ -94,12 +98,16 @@ function sessionKey(baseUrl: string, username: string): string {
   return `${baseUrl}|${username}`
 }
 
-async function getTlSession(baseUrl: string, creds: TlCredentials): Promise<string> {
+async function getTlSession(
+  baseUrl: string,
+  creds: TlCredentials,
+  proxyAgent?: FetchOptions["proxyAgent"]
+): Promise<string> {
   const key = sessionKey(baseUrl, creds.username)
   const cached = tlSessionCache.get(key)
   if (cached) return cached
 
-  const cookies = await login(baseUrl, creds)
+  const cookies = await login(baseUrl, creds, proxyAgent)
   tlSessionCache.set(key, cookies)
   return cookies
 }
@@ -108,7 +116,11 @@ function invalidateTlSession(baseUrl: string, username: string): void {
   tlSessionCache.delete(sessionKey(baseUrl, username))
 }
 
-async function login(baseUrl: string, creds: TlCredentials): Promise<string> {
+async function login(
+  baseUrl: string,
+  creds: TlCredentials,
+  proxyAgent?: FetchOptions["proxyAgent"]
+): Promise<string> {
   const loginUrl = `${baseUrl}/user/account/login/`
   const form: Record<string, string> = {
     username: creds.username,
@@ -123,19 +135,39 @@ async function login(baseUrl: string, creds: TlCredentials): Promise<string> {
     Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
   }
 
-  let response: Response
+  let setCookieHeaders: string[]
+  let loginStatus: number
+  let readBody: () => Promise<string>
   try {
-    response = await fetch(loginUrl, {
-      method: "POST",
-      headers,
-      body,
-      redirect: "manual",
-      signal: AbortSignal.timeout(ADAPTER_FETCH_TIMEOUT_MS),
-    })
+    if (proxyAgent) {
+      // https.request does not follow redirects, which is what `redirect:
+      // "manual"` buys on the direct path — TL answers a good login with a 302
+      // that carries the session cookie.
+      const res = await proxyFetch(loginUrl, proxyAgent, {
+        method: "POST",
+        body,
+        headers,
+        timeoutMs: ADAPTER_FETCH_TIMEOUT_MS,
+      })
+      const raw = res.headers["set-cookie"]
+      setCookieHeaders = Array.isArray(raw) ? raw : raw ? [raw] : []
+      loginStatus = res.status
+      readBody = () => res.text()
+    } else {
+      const response = await fetch(loginUrl, {
+        method: "POST",
+        headers,
+        body,
+        redirect: "manual",
+        signal: AbortSignal.timeout(ADAPTER_FETCH_TIMEOUT_MS),
+      })
+      setCookieHeaders = response.headers.getSetCookie?.() ?? []
+      loginStatus = response.status
+      readBody = () => response.text()
+    }
   } catch (err) {
     throw classifyFetchError(err, new URL(baseUrl).hostname)
   }
-  const setCookieHeaders = response.headers.getSetCookie?.() ?? []
 
   const cookiePairs = setCookieHeaders
     .map((raw) => raw.split(";")[0]?.trim())
@@ -153,12 +185,12 @@ async function login(baseUrl: string, creds: TlCredentials): Promise<string> {
   // The body is only inspected when the response was not a redirect: a 302
   // carries no body, and a 200 that does NOT look like the login page is still
   // accepted, so a future flow that returns 200 on success would not regress.
-  const authenticated = cookieString.includes("tluid=") && isRedirect(response.status)
+  const authenticated = cookieString.includes("tluid=") && isRedirect(loginStatus)
   if (!authenticated) {
     let html = ""
-    if (!isRedirect(response.status)) {
+    if (!isRedirect(loginStatus)) {
       try {
-        html = await response.text()
+        html = await readBody()
       } catch {
         // Body already consumed or connection dropped — fall through to the
         // generic message rather than masking the login failure with a read error.
@@ -304,7 +336,7 @@ export class TorrentleechAdapter implements TrackerAdapter {
     const creds = parseTlCredentials(apiToken)
     const profileUrl = `${baseUrl}/profile/${encodeURIComponent(creds.username)}`
 
-    let cookies = await getTlSession(baseUrl, creds)
+    let cookies = await getTlSession(baseUrl, creds, options?.proxyAgent)
     let html: string
     try {
       html = await fetchHtml(profileUrl, cookies, options?.proxyAgent)
@@ -313,7 +345,7 @@ export class TorrentleechAdapter implements TrackerAdapter {
       // the login page. Drop it and authenticate once more before giving up.
       if (!(err instanceof Error) || !err.message.startsWith("Session expired")) throw err
       invalidateTlSession(baseUrl, creds.username)
-      cookies = await getTlSession(baseUrl, creds)
+      cookies = await getTlSession(baseUrl, creds, options?.proxyAgent)
       html = await fetchHtml(profileUrl, cookies, options?.proxyAgent)
     }
     return parseTlProfile(html, creds.username)
@@ -330,7 +362,7 @@ export class TorrentleechAdapter implements TrackerAdapter {
     const endpoint = `/profile/${creds.username}`
 
     try {
-      const cookies = await getTlSession(baseUrl, creds)
+      const cookies = await getTlSession(baseUrl, creds, options?.proxyAgent)
       const profileUrl = `${baseUrl}${endpoint}`
       const html = await fetchHtml(profileUrl, cookies, options?.proxyAgent)
       const stats = parseTlProfile(html, creds.username)

--- a/src/lib/tunnel.ts
+++ b/src/lib/tunnel.ts
@@ -3,7 +3,7 @@
 // Functions: buildProxyUrl, createProxyAgent, proxyFetch, buildProxyAgentFromSettings
 // Exports: VALID_PROXY_TYPES, PROXY_HOST_PATTERN, ProxyType, ProxyConfig, ProxyFetchResult, ProxySettings
 
-import type { Agent as HttpAgent } from "node:http"
+import type { Agent as HttpAgent, IncomingHttpHeaders } from "node:http"
 import https from "node:https"
 import { HttpsProxyAgent } from "https-proxy-agent"
 import { SocksProxyAgent } from "socks-proxy-agent"
@@ -54,7 +54,15 @@ export interface ProxyFetchResult {
   ok: boolean
   status: number
   statusText: string
+  /**
+   * Raw response headers. Present because a login POST is only useful if the
+   * caller can read the Set-Cookie it came for — without this, an adapter that
+   * authenticates has no way to go through the proxy and must fall back to a
+   * direct fetch, which defeats the point of configuring one.
+   */
+  headers: IncomingHttpHeaders
   json: () => Promise<unknown>
+  text: () => Promise<string>
   buffer: () => Promise<Buffer>
 }
 
@@ -114,8 +122,10 @@ export function proxyFetch(
             ok: (res.statusCode ?? 0) >= 200 && (res.statusCode ?? 0) < 300,
             status: res.statusCode ?? 0,
             statusText: res.statusMessage ?? "",
+            headers: res.headers,
             // security-audit-ignore: async wrapper converts JSON.parse throw to rejected promise. Caller handles via await/catch
             json: async () => JSON.parse(raw.toString("utf8")),
+            text: () => Promise.resolve(raw.toString("utf8")),
             buffer: () => Promise.resolve(raw),
           })
         })


### PR DESCRIPTION
## Summary

Four fixes to the TorrentLeech adapter, in the order they surfaced. They are one PR
because they are one story — *the adapter cannot authenticate a 2FA account, and once it
can, the figures it reports are wrong* — and because they are not independently
reviewable: each one is only observable after the one before it lands.

| # | Commit | Fixes |
|---|---|---|
| 1 | `feat(trackers): support TorrentLeech's Alt 2FA Token` | 2FA accounts cannot be polled at all |
| 2 | `fix(trackers): stop trusting TorrentLeech's cookies on a refused login` | a rejected login is cached as a success |
| 3 | `fix(trackers): send the TorrentLeech login through the configured proxy` | the login POST ignores the configured proxy |
| 4 | `fix(trackers): correct six wrong figures in the profile parser` | 6 of 8 parsed fields are wrong |

---

## 1 — Alt 2FA Token

A TorrentLeech account with 2FA enabled cannot be polled. Its login form takes a third
input, `alt2FAToken`.

It is **not** a TOTP secret, and nothing here computes a one-time code. TorrentLeech
issues a **static** token for exactly this case, at *Site Profile → Alt 2FA Token*, and
that is how other clients drive this login.

- `TlCredentials` gains an optional `alt2FAToken`.
- Accepted as `alt2FAToken` or `alt2fatoken` — the latter is how some clients store it,
  and being strict about the capitalisation of a pasted token helps nobody.
- Sent **only when set**, so the request for a non-2FA account is byte-identical to
  before.
- Optional field added to both credential entry points (`AddTrackerDialog`,
  `TrackerSettingsSheet`).

## 2 — The login success check was wrong

This is the more important half, and it is why commit 1 alone would not have worked.

Measured against the live site:

| | no token (refused) | with token (accepted) |
|---|---|---|
| status | **200** | **302** |
| cookies set | `tluid`, `tlpass`, `member_id`, `pass_hash`, `session_id` | `tluid`, `tlpass` |
| the profile page afterwards | the login page | the real profile |

**TorrentLeech sets session cookies on a rejected login.** The check was "did we get a
`tluid`", so a refusal looked like a success. The never-signed-in session was cached,
and every subsequent page fetch came back as the login page — surfaced to the user as
**"Session expired — TorrentLeech cookies need to be refreshed"**, sending them off to
refresh a session that never existed.

It also made commit 1's 2FA detection unreachable: the cookie check passed before
anything read the response body.

The check is now `tluid` **and** a redirect status. When the response is not a redirect
the body is inspected, and it rejects only on **positive** evidence of a refusal — the
`One Time Password` heading, a `login-form`, or a link to `/user/account/login`. A 200
that does not look like the login page is still accepted, so this tightens a wrong check
without inventing a new way to fail for anyone it works for today.

The error message now names the fix: *"TorrentLeech requires 2FA — add your Alt 2FA
Token (Site Profile → Alt 2FA Token) to this tracker's credentials"*.

## 3 — The login POST bypassed the configured proxy

The profile GET was proxied. **The login POST was not.** A user who has configured a
proxy still sent their real address to the tracker on every re-authentication — the one
request in the flow that carries their password. For anyone proxying because the tracker
must only ever see one specific exit address, that is the feature failing on its most
sensitive request.

**The code said this was impossible, and the code was out of date.** The comment read
*"proxyFetch is GET-only with no body support"*. `proxyFetch` has accepted `method` and
`body` for some time. The real gap was narrower: it **discarded the response headers**,
so a caller could not read the `Set-Cookie` it had just logged in for.

- `ProxyFetchResult` now exposes `headers` and a `text()` method.
  This is the part that generalises: **without response headers, no adapter that
  authenticates can ever use the proxy**, so this unblocks more than TorrentLeech.
- `login()` uses `proxyFetch` when a `proxyAgent` is present and keeps the direct
  `fetch` otherwise — nothing changes for users with no proxy configured.
- `https.request` does not follow redirects, which matches the `redirect: "manual"` the
  direct path already relies on to catch the 302 that carries the session cookie.

Tests assert the login goes through the proxy **and** that nothing goes out the direct
path at all.

## 4 — Six wrong figures in the profile parser

Once commits 1–3 let the adapter authenticate, everything it reported except `username`
and `uploaded` turned out to be wrong. Every one of them is wrong in a way that looks
plausible rather than broken, which is why none of it surfaced.

| field | what the parser produced | what the page says |
|---|---|---|
| user class | `ic TL` | the actual class |
| downloaded | `0 bytes` | the real figure |
| ratio | `Infinity` | the real ratio |
| buffer | the entire upload total | uploaded − downloaded |
| seeding count | the leading digits of a byte total | the torrent count |
| leeching count | the leading digits of a byte total | the torrent count |
| hit and runs | `null` | the real count |

### `.profile-downloaded-details` does not exist

The markup is asymmetric. Only the uploaded figure carries a details class:

```html
<div class="profile-uploaded">
  uploaded:<span class="profile-info-details profile-uploaded-details">10.5 GB</span>
</div>
<div class="profile-downloaded">
  downloaded: <span class="profile-info-details">5.25 GB</span>
</div>
```

`.profile-downloaded-details` matches nothing, so **every** account parses as having
downloaded zero bytes. That is not cosmetic: `computeRatio` then returns `Infinity` and
`computeBufferBytes` returns the full upload total, so an account that owes the tracker
is reported as unconditionally healthy — and `checkRatioBelowMinimum` can never fire,
because `Infinity < minimumRatio` is false.

Both figures are now read through their parent container, with the details class kept
first in case the markup is ever made symmetric.

### The user class regex matched a nav link

The class was matched with `/Class:?\s*\n?\s*([A-Za-z][A-Za-z ]*)/` against the whole
document's text. Every TorrentLeech page carries this in its nav:

```html
<li><a href="http://classic.torrentleech.org">Classic TL</a></li>
```

`Class` + `ic TL` — and the nav comes before the profile table, so it wins. The pattern
captured `ic TL` for **every account on the site**.

Now read from `.label-user-class`, falling back to the `Class` row of the profile table,
falling back to `"User"`.

### Torrent counts read the size next to them

The counts live in the top bar, where a cell reads `10.5 GB (12)` — a size, then the
count in parentheses. The old code took the *first* number in the cell, which is the
leading digits of the byte total: a plausible-looking torrent count that is really a
size. Now anchored on the parentheses, and reports `0` rather than a guess when they are
absent.

### Hit and runs were hardcoded `null`

`hitAndRuns: null` means "this tracker does not expose it". The page has a
`title="Hit and Run"` cell, and always did. For a dashboard whose purpose is catching
hit and runs, that is the number that matters most.

### Also

TL Points now read from the `.total-TL-points` span rather than a `TL Points:` text
match, with the old match kept as a fallback. Generally: class and points now come from
semantic markup, so a layout change degrades to a fallback instead of silently returning
a wrong answer.

### The tests could not have caught any of this

The fixture was written from the same assumption as the parser — it invented a
`profile-downloaded-details` span the site never emits — so it agreed with the bug
rather than catching it. It is replaced with markup copied from a live page, nav link
and top bar and asymmetric spans intact, and the parser reproduces every figure on that
page including the buffer TorrentLeech prints itself.

---

## Reviewer note — a drive-by, deliberately flagged

`AddTrackerDialog`'s `resetForm` never cleared the TorrentLeech username and password,
so a closed dialog kept the password in component state and re-showed it on reopen.
Adding a third secret without fixing that would have made it worse, so it is fixed here.
Clean three-line lift if you'd rather it were separate.

## Changes

| File | Action |
|------|--------|
| `src/lib/adapters/torrentleech.ts` | **Edit** (2FA, login check, proxy, parser) |
| `src/lib/adapters/torrentleech.test.ts` | **Edit** (real-markup fixture, +27 tests) |
| `src/lib/tunnel.ts` | **Edit** (`ProxyFetchResult` gains `headers` + `text()`) |
| `src/components/AddTrackerDialog.tsx` | **Edit** (optional token field, `resetForm` fix) |
| `src/components/TrackerSettingsSheet.tsx` | **Edit** (optional token field) |

**5 files edited — 677 insertions, 59 deletions**
**Tests: 4260 passing (27 new) | TypeScript: clean | Biome: clean**

Verified end to end ✅ — all four fixes exercised against real responses, with every
parsed figure cross-checked field by field against the profile markup it comes from.

---

## Disclosure

Written with AI assistance — the commits carry a `Co-Authored-By` trailer to that effect.

What that did and didn't mean here: all four of these bugs were found by running the
adapter and reading what actually came back, not by a model inspecting the source and
guessing. The 200-vs-302 table is a real measurement, and the parser bugs were diagnosed by
running the real profile markup through `parseTlProfile`'s selectors — which is also why the
replacement test fixture is copied from that markup rather than invented. Every fix was
re-verified the same way afterwards.

I've read the diff and can walk through any part of it.

