### PR TITLE
feat(trackers): let a tracker state an either/or seeding requirement

### DIFF
--- a/src/components/dashboard/TorrentsTab.tsx
+++ b/src/components/dashboard/TorrentsTab.tsx
@@ -307,14 +307,14 @@ function TorrentsTab({
       </LazySection>
 
       {/* Unsatisfied Torrents */}
-      {data.requiredSeedSeconds && (
+      {data.requirement && (
         <div className="flex flex-col gap-3">
           <H2 className="uppercase tracking-wider">
             Unsatisfied Torrents ({data.unsatisfiedSorted.length})
           </H2>
           <UnsatisfiedTorrentsTable
             torrents={data.unsatisfiedSorted}
-            requiredSeconds={data.requiredSeedSeconds}
+            requirement={data.requirement}
             accentColor={accentColor}
           />
         </div>

--- a/src/components/dashboard/__tests__/TorrentsTabEmptyStates.test.tsx
+++ b/src/components/dashboard/__tests__/TorrentsTabEmptyStates.test.tsx
@@ -98,6 +98,7 @@ function makeData(overrides: Partial<TrackerTorrentsData> = {}): TrackerTorrents
     totalUpSpeed: 0,
     totalSize: 0,
     crossSeeded: [],
+    requirement: null,
     requiredSeedSeconds: null,
     unsatisfiedTorrents: [],
     unsatisfiedSorted: [],

--- a/src/components/dashboard/torrents/UnsatisfiedTorrentsTable.tsx
+++ b/src/components/dashboard/torrents/UnsatisfiedTorrentsTable.tsx
@@ -6,28 +6,38 @@ import { MarqueeText } from "@/components/ui/MarqueeText"
 import type { Column } from "@/components/ui/Table"
 import { Table } from "@/components/ui/Table"
 import type { TorrentRaw } from "@/lib/fleet"
-import { formatBytesNum, formatDuration, formatPercent } from "@/lib/formatters"
+import { formatBytesNum, formatDuration, formatPercent, formatRatio } from "@/lib/formatters"
+import {
+  ratioProgress,
+  type SatisfactionRequirement,
+  satisfactionProgress,
+  seedTimeProgress,
+} from "@/lib/satisfaction"
 
 interface UnsatisfiedTorrentsTableProps {
   torrents: TorrentRaw[]
-  requiredSeconds: number
+  requirement: SatisfactionRequirement
   accentColor: string
 }
 
 export function UnsatisfiedTorrentsTable({
   torrents,
-  requiredSeconds,
+  requirement,
   accentColor,
 }: UnsatisfiedTorrentsTableProps) {
   const pctColor = (p: number) =>
     p < 50 ? CHART_THEME.danger : p < 80 ? CHART_THEME.warn : CHART_THEME.positive
+
+  const showSeedTime = requirement.requiredSeedSeconds !== null
+  const showRatio = requirement.requiredRatio !== null
+  const eitherOr = requirement.mode === "any" && showSeedTime && showRatio
 
   const columns: Column<TorrentRaw>[] = [
     {
       key: "name",
       header: "Name",
       render: (t) => {
-        const pct = Math.min((t.seedingTime / requiredSeconds) * 100, 100)
+        const pct = satisfactionProgress(t, requirement) * 100
         return (
           <div className="flex flex-col gap-2 min-w-0">
             <MarqueeText className="text-xs font-mono text-secondary">{t.name}</MarqueeText>
@@ -60,42 +70,93 @@ export function UnsatisfiedTorrentsTable({
         </span>
       ),
     },
-    {
+  ]
+
+  if (showSeedTime) {
+    columns.push({
       key: "seedTime",
       header: "Seed Time",
       align: "right",
       width: "12%",
       render: (t) => {
-        const pct = Math.min((t.seedingTime / requiredSeconds) * 100, 100)
+        const pct = seedTimeProgress(t.seedingTime, requirement) * 100
         return (
           <span className="text-xs font-mono whitespace-nowrap" style={{ color: pctColor(pct) }}>
             {formatDuration(t.seedingTime)}
           </span>
         )
       },
-    },
-    {
-      key: "remaining",
-      header: "Remaining",
+    })
+  }
+
+  if (showRatio) {
+    columns.push({
+      key: "ratio",
+      header: "Ratio",
       align: "right",
-      width: "12%",
+      width: "10%",
       render: (t) => {
-        const remaining = Math.max(requiredSeconds - t.seedingTime, 0)
+        const pct = ratioProgress(t.ratio, requirement) * 100
         return (
-          <span className="text-xs font-mono text-muted whitespace-nowrap">
-            {remaining > 0 ? formatDuration(remaining) : "Done"}
+          <span className="text-xs font-mono whitespace-nowrap" style={{ color: pctColor(pct) }}>
+            {formatRatio(t.ratio)}
           </span>
         )
       },
+    })
+  }
+
+  columns.push({
+    key: "remaining",
+    header: "Remaining",
+    align: "right",
+    width: "14%",
+    render: (t) => {
+      // Under an either/or the honest answer is the nearer route, and saying
+      // "6 days" at a 0.98 ratio would send someone to delete a torrent that is
+      // an hour from clearing. Which route is nearer is shown, not just how far.
+      const seedPct = seedTimeProgress(t.seedingTime, requirement)
+      const ratioPct = ratioProgress(t.ratio, requirement)
+
+      if (eitherOr && ratioPct > seedPct) {
+        const owed = (requirement.requiredRatio ?? 0) - (Number.isFinite(t.ratio) ? t.ratio : 0)
+        return (
+          <span className="text-xs font-mono text-muted whitespace-nowrap">
+            {formatRatio(Math.max(owed, 0))} ratio
+          </span>
+        )
+      }
+
+      if (!showSeedTime) {
+        const owed = (requirement.requiredRatio ?? 0) - (Number.isFinite(t.ratio) ? t.ratio : 0)
+        return (
+          <span className="text-xs font-mono text-muted whitespace-nowrap">
+            {formatRatio(Math.max(owed, 0))} ratio
+          </span>
+        )
+      }
+
+      const remaining = Math.max((requirement.requiredSeedSeconds ?? 0) - t.seedingTime, 0)
+      return (
+        <span className="text-xs font-mono text-muted whitespace-nowrap">
+          {remaining > 0 ? formatDuration(remaining) : "Done"}
+        </span>
+      )
     },
-  ]
+  })
+
+  const emptyMessage = eitherOr
+    ? "All torrents meet the seed time or ratio requirement"
+    : showRatio && !showSeedTime
+      ? "All torrents meet ratio requirements"
+      : "All torrents meet seed time requirements"
 
   return (
     <Table<TorrentRaw>
       columns={columns}
       data={torrents}
       keyExtractor={(t) => t.hash}
-      emptyMessage="All torrents meet seed time requirements"
+      emptyMessage={emptyMessage}
       surface="inset"
       trackerColor={accentColor}
       fixedLayout

--- a/src/data/tracker-registry.ts
+++ b/src/data/tracker-registry.ts
@@ -3,6 +3,7 @@
 import type { PlatformType } from "@/lib/adapters/constants"
 import type { GazelleAuthStyle, Unit3dAuthStyle } from "@/lib/adapters/types"
 import { normalizeUrl } from "@/lib/data-transforms"
+import type { SatisfactionMode } from "@/lib/satisfaction"
 import type { TrackerCredentialFieldDefinition } from "@/lib/tracker-credentials/types"
 import { ALL_TRACKERS } from "./trackers"
 
@@ -36,6 +37,19 @@ export interface TrackerUserClass {
 export interface TrackerRules {
   minimumRatio: number // 0 = no minimum
   seedTimeHours: number // 0 = no minimum
+  /**
+   * How the per-torrent requirements above combine. See `@/lib/satisfaction`.
+   *
+   * Omit it unless the tracker's own rules have been read: an entry without a
+   * mode keeps the historical behaviour of judging satisfaction on seed time
+   * alone, and `minimumRatio` stays what it has always been here, an
+   * ACCOUNT-level figure for the ratio-danger alert.
+   *
+   * Setting `"any"` where the tracker means "and" marks torrents satisfied that
+   * are not, which is how hit-and-runs are earned. Only set it from the site's
+   * own wording.
+   */
+  satisfactionMode?: SatisfactionMode
   loginIntervalDays: number // days until prune/disable
   fulfillmentPeriodHours?: number // null = not applicable
   hnrBanLimit?: number // null = not applicable

--- a/src/data/trackers/torrentleech.ts
+++ b/src/data/trackers/torrentleech.ts
@@ -36,8 +36,17 @@ export const torrentleech: TrackerRegistryEntry = {
 
   // ── Rules ───────────────────────────────────────────────────────────
   rules: {
+    // Both routes, verbatim from wiki.torrentleech.org/doku.php/hnr: "There are
+    // two ways for you to give back to the community" — seed a torrent to at
+    // least 1:1, OR seed it for the minimum time required for your user class.
+    // Hence `any`. FreeLeech is explicitly NOT exempt from either.
     minimumRatio: 1.0,
-    seedTimeHours: 0,
+    // 10 days, the Registered-class requirement and the longest one on the
+    // site (Power User 8d, Super User 7d, Extreme User 6d, TL GOD 4d, VIP
+    // none). Deliberately the longest: the class is not knowable from the
+    // registry, and over-seeding is the safe direction to be wrong in.
+    seedTimeHours: 240,
+    satisfactionMode: "any",
     loginIntervalDays: 0,
   },
 

--- a/src/hooks/useTrackerTorrents.ts
+++ b/src/hooks/useTrackerTorrents.ts
@@ -8,6 +8,12 @@ import { usePollingIntervals } from "@/hooks/usePollingIntervals"
 import type { TorrentRaw } from "@/lib/fleet"
 import type { TagGroupBreakdown } from "@/lib/fleet-aggregation"
 import {
+  isSatisfied,
+  resolveSatisfaction,
+  type SatisfactionRequirement,
+  satisfactionProgress,
+} from "@/lib/satisfaction"
+import {
   type AggregatedTorrentsResponse,
   type CategoryStats,
   LEECHING_STATES,
@@ -57,6 +63,9 @@ interface TrackerTorrentsData {
   totalUpSpeed: number
   totalSize: number
   crossSeeded: TorrentRaw[]
+  /** The resolved per-torrent rule, or null when this tracker states none. */
+  requirement: SatisfactionRequirement | null
+  /** Kept for the seed-time chart marker; null when seed time is not required. */
   requiredSeedSeconds: number | null
   unsatisfiedTorrents: TorrentRaw[]
   unsatisfiedSorted: TorrentRaw[]
@@ -245,14 +254,19 @@ function useTrackerTorrents({
       return tags.some((tag) => csTagSet.has(tag))
     })
 
-    const requiredSeedSeconds =
-      rules?.seedTimeHours != null && rules.seedTimeHours > 0 ? rules.seedTimeHours * 3600 : null
-    const unsatisfiedTorrents = requiredSeedSeconds
-      ? torrents.filter((t) => t.seedingTime < requiredSeedSeconds)
+    // Satisfaction is no longer seed time alone. A tracker that states an
+    // either/or — TorrentLeech's "two ways for you to give back" — has torrents
+    // that are done at 1:1 with no seed time on the clock, and a rule that
+    // ignores ratio keeps them forever. See @/lib/satisfaction for why ratio
+    // only counts for entries that declare a mode.
+    const requirement = resolveSatisfaction(rules)
+    const requiredSeedSeconds = requirement?.requiredSeedSeconds ?? null
+    const unsatisfiedTorrents = requirement
+      ? torrents.filter((t) => !isSatisfied(t, requirement))
       : []
-    const unsatisfiedCount = requiredSeedSeconds ? unsatisfiedTorrents.length : null
+    const unsatisfiedCount = requirement ? unsatisfiedTorrents.length : null
 
-    const hnrRiskCount = requiredSeedSeconds
+    const hnrRiskCount = requirement
       ? unsatisfiedTorrents.filter(
           (t) => !SEEDING_STATES.has(t.state) && !LEECHING_STATES.has(t.state)
         ).length
@@ -289,8 +303,13 @@ function useTrackerTorrents({
       .sort((a, b) => a.addedAt - b.addedAt)
       .slice(0, 10)
 
-    const unsatisfiedSorted = requiredSeedSeconds
-      ? [...unsatisfiedTorrents].sort((a, b) => b.seedingTime - a.seedingTime)
+    // Closest to satisfied first. Sorting on seed time alone put a torrent at
+    // 0.99 ratio — one that could be released within the hour — below one with
+    // days of seeding and no chance of clearing on ratio.
+    const unsatisfiedSorted = requirement
+      ? [...unsatisfiedTorrents].sort(
+          (a, b) => satisfactionProgress(b, requirement) - satisfactionProgress(a, requirement)
+        )
       : []
 
     const torrentTagSets = torrents.map((t) => new Set(parseTorrentTags(t.tags, false)))
@@ -340,6 +359,7 @@ function useTrackerTorrents({
       totalUpSpeed,
       totalSize,
       crossSeeded,
+      requirement,
       requiredSeedSeconds,
       unsatisfiedTorrents,
       unsatisfiedSorted,

--- a/src/lib/satisfaction.test.ts
+++ b/src/lib/satisfaction.test.ts
@@ -1,0 +1,223 @@
+// src/lib/satisfaction.test.ts
+
+import { describe, expect, it } from "vitest"
+import type { TrackerRules } from "@/data/tracker-registry"
+import {
+  isSatisfied,
+  ratioProgress,
+  remainingSeedSeconds,
+  resolveSatisfaction,
+  type SatisfactionRequirement,
+  satisfactionProgress,
+  seedTimeProgress,
+} from "./satisfaction"
+
+const HOUR = 3600
+
+function rules(overrides: Partial<TrackerRules> = {}): TrackerRules {
+  return { minimumRatio: 0, seedTimeHours: 0, loginIntervalDays: 0, ...overrides }
+}
+
+function torrent(seedingTime: number, ratio: number) {
+  return { seedingTime, ratio }
+}
+
+describe("resolveSatisfaction", () => {
+  it("returns null when the tracker states no requirement", () => {
+    expect(resolveSatisfaction(rules())).toBeNull()
+    expect(resolveSatisfaction(undefined)).toBeNull()
+  })
+
+  it("ignores minimumRatio for an entry that declares no mode", () => {
+    // The compatibility guarantee. minimumRatio has always been an ACCOUNT-level
+    // figure here; reading it per-torrent for the 55 entries that predate this
+    // field would re-interpret rules nobody has re-read.
+    const req = resolveSatisfaction(rules({ minimumRatio: 1.0, seedTimeHours: 72 }))
+    expect(req).toEqual({ requiredSeedSeconds: 72 * HOUR, requiredRatio: null, mode: "all" })
+  })
+
+  it("returns null for a ratio-only entry that has not opted in", () => {
+    expect(resolveSatisfaction(rules({ minimumRatio: 1.0 }))).toBeNull()
+  })
+
+  it("picks up ratio once a mode is declared", () => {
+    const req = resolveSatisfaction(
+      rules({ minimumRatio: 1.0, seedTimeHours: 240, satisfactionMode: "any" })
+    )
+    expect(req).toEqual({ requiredSeedSeconds: 240 * HOUR, requiredRatio: 1.0, mode: "any" })
+  })
+
+  it("allows a ratio-only rule when the mode is declared", () => {
+    const req = resolveSatisfaction(rules({ minimumRatio: 1.0, satisfactionMode: "any" }))
+    expect(req).toEqual({ requiredSeedSeconds: null, requiredRatio: 1.0, mode: "any" })
+  })
+
+  it("returns null for a declared mode over no thresholds at all", () => {
+    expect(resolveSatisfaction(rules({ satisfactionMode: "any" }))).toBeNull()
+  })
+})
+
+describe("either/or satisfaction", () => {
+  const req: SatisfactionRequirement = {
+    requiredSeedSeconds: 240 * HOUR,
+    requiredRatio: 1.0,
+    mode: "any",
+  }
+
+  it("satisfies on ratio alone with no seed time", () => {
+    expect(isSatisfied(torrent(0, 1.2), req)).toBe(true)
+  })
+
+  it("satisfies on seed time alone with a ratio of zero", () => {
+    expect(isSatisfied(torrent(240 * HOUR, 0), req)).toBe(true)
+  })
+
+  it("leaves a torrent short on both unsatisfied", () => {
+    expect(isSatisfied(torrent(100 * HOUR, 0.5), req)).toBe(false)
+  })
+
+  it("satisfies at exactly the ratio threshold", () => {
+    expect(isSatisfied(torrent(0, 1.0), req)).toBe(true)
+  })
+
+  it("reports progress as the nearer of the two routes", () => {
+    // 25% of the seed time but 90% of the ratio: an hour of seeding could clear
+    // it, so it is 90% done, not 25%.
+    expect(satisfactionProgress(torrent(60 * HOUR, 0.9), req)).toBeCloseTo(0.9)
+  })
+})
+
+describe("all-of satisfaction", () => {
+  const req: SatisfactionRequirement = {
+    requiredSeedSeconds: 72 * HOUR,
+    requiredRatio: 1.0,
+    mode: "all",
+  }
+
+  it("is unsatisfied when only the ratio is met", () => {
+    expect(isSatisfied(torrent(0, 5.0), req)).toBe(false)
+  })
+
+  it("is unsatisfied when only the seed time is met", () => {
+    expect(isSatisfied(torrent(100 * HOUR, 0.2), req)).toBe(false)
+  })
+
+  it("is satisfied when both are met", () => {
+    expect(isSatisfied(torrent(100 * HOUR, 1.5), req)).toBe(true)
+  })
+
+  it("reports progress as the laggard", () => {
+    expect(satisfactionProgress(torrent(72 * HOUR, 0.3), req)).toBeCloseTo(0.3)
+  })
+})
+
+describe("seed-time-only satisfaction (the historical behaviour)", () => {
+  const req: SatisfactionRequirement = {
+    requiredSeedSeconds: 72 * HOUR,
+    requiredRatio: null,
+    mode: "all",
+  }
+
+  it("ignores ratio entirely", () => {
+    expect(isSatisfied(torrent(72 * HOUR, 0), req)).toBe(true)
+    expect(isSatisfied(torrent(71 * HOUR, 99), req)).toBe(false)
+  })
+})
+
+describe("ratioProgress", () => {
+  const req: SatisfactionRequirement = {
+    requiredSeedSeconds: null,
+    requiredRatio: 1.0,
+    mode: "any",
+  }
+
+  it("treats an infinite ratio as no progress, not as complete", () => {
+    // A torrent that has downloaded nothing reports Infinity in some clients.
+    // Reading that as "1000% of the requirement" would mark it satisfied, which
+    // is the unsafe direction — this is exactly how the TorrentLeech adapter's
+    // zero-download parse would have poisoned the table.
+    expect(ratioProgress(Number.POSITIVE_INFINITY, req)).toBe(0)
+  })
+
+  it("treats a negative sentinel ratio as no progress", () => {
+    // Transmission uses -1 for "not applicable".
+    expect(ratioProgress(-1, req)).toBe(0)
+  })
+
+  it("treats NaN as no progress", () => {
+    expect(ratioProgress(Number.NaN, req)).toBe(0)
+  })
+
+  it("caps at 1", () => {
+    expect(ratioProgress(50, req)).toBe(1)
+  })
+
+  it("is 1 when ratio is not required", () => {
+    expect(ratioProgress(0, { requiredSeedSeconds: HOUR, requiredRatio: null, mode: "all" })).toBe(1)
+  })
+})
+
+describe("seedTimeProgress", () => {
+  const req: SatisfactionRequirement = {
+    requiredSeedSeconds: 100,
+    requiredRatio: null,
+    mode: "all",
+  }
+
+  it("is a fraction of the requirement", () => {
+    expect(seedTimeProgress(25, req)).toBeCloseTo(0.25)
+  })
+
+  it("caps at 1", () => {
+    expect(seedTimeProgress(1000, req)).toBe(1)
+  })
+
+  it("is 1 when seed time is not required", () => {
+    expect(
+      seedTimeProgress(0, { requiredSeedSeconds: null, requiredRatio: 1, mode: "any" })
+    ).toBe(1)
+  })
+})
+
+describe("remainingSeedSeconds", () => {
+  const req: SatisfactionRequirement = {
+    requiredSeedSeconds: 240 * HOUR,
+    requiredRatio: 1.0,
+    mode: "any",
+  }
+
+  it("reports what is still owed", () => {
+    expect(remainingSeedSeconds(torrent(40 * HOUR, 0.1), req)).toBe(200 * HOUR)
+  })
+
+  it("reports null once the torrent is satisfied by ratio", () => {
+    // Not "200 hours remaining". Nothing is owed — the torrent is free to go.
+    expect(remainingSeedSeconds(torrent(40 * HOUR, 1.5), req)).toBeNull()
+  })
+
+  it("reports null when seed time is not a route here", () => {
+    expect(
+      remainingSeedSeconds(torrent(0, 0.5), {
+        requiredSeedSeconds: null,
+        requiredRatio: 1,
+        mode: "any",
+      })
+    ).toBeNull()
+  })
+})
+
+describe("TorrentLeech, end to end", () => {
+  // The case that motivated this: seedTimeHours was 0, so the whole unsatisfied
+  // table silently disappeared for TorrentLeech.
+  it("produces a real requirement from the registry entry", async () => {
+    const { getTrackerBySlug } = await import("@/data/tracker-registry")
+    const tl = getTrackerBySlug("torrentleech")
+    expect(tl, "torrentleech is in the registry").toBeDefined()
+
+    const req = resolveSatisfaction(tl?.rules)
+    expect(req).not.toBeNull()
+    expect(req?.mode).toBe("any")
+    expect(req?.requiredRatio).toBe(1.0)
+    expect(req?.requiredSeedSeconds).toBe(240 * HOUR)
+  })
+})

--- a/src/lib/satisfaction.ts
+++ b/src/lib/satisfaction.ts
@@ -1,0 +1,117 @@
+// src/lib/satisfaction.ts
+//
+// Functions: resolveSatisfaction, seedTimeProgress, ratioProgress,
+//            satisfactionProgress, isSatisfied, remainingSeedSeconds
+
+import type { TrackerRules } from "@/data/tracker-registry"
+
+/**
+ * How a torrent's per-torrent requirements combine.
+ *
+ * - `any` — meeting ONE of them satisfies the torrent. TorrentLeech states it
+ *   outright: "There are two ways for you to give back to the community" —
+ *   seed to 1:1, or seed for your class's minimum time.
+ * - `all` — every stated requirement must be met.
+ *
+ * Never assume `any` for a tracker that does not say so. Marking a torrent
+ * satisfied at 1:1 on a seed-time-only tracker is how hit-and-runs are earned,
+ * and it is the one direction this model must not fail in.
+ */
+export type SatisfactionMode = "any" | "all"
+
+/** The resolved, per-torrent requirement for one tracker. */
+export interface SatisfactionRequirement {
+  /** null = seed time is not part of this tracker's rule. */
+  requiredSeedSeconds: number | null
+  /** null = per-torrent ratio is not part of this tracker's rule. */
+  requiredRatio: number | null
+  mode: SatisfactionMode
+}
+
+/**
+ * Reads a registry entry's rules into a requirement, or null when the tracker
+ * states no per-torrent requirement at all.
+ *
+ * **Ratio participates only when `satisfactionMode` is set.** `minimumRatio` has
+ * always been in the registry, but as an ACCOUNT-level figure — it drives the
+ * ratio-danger alert and the chart baseline. Reading it as a per-torrent
+ * requirement wherever it happens to be non-zero would silently re-interpret all
+ * 55 registry entries against rules nobody has re-read, and for a tracker whose
+ * real rule is seed-time-only that lands in the unsafe direction.
+ *
+ * So an entry opts in by declaring its mode, and an entry that has not opted in
+ * behaves exactly as it does today. That makes `satisfactionMode` a marker of
+ * "these rules have been verified" as much as a combinator.
+ */
+export function resolveSatisfaction(rules?: TrackerRules): SatisfactionRequirement | null {
+  const seedTimeHours = rules?.seedTimeHours ?? 0
+  const requiredSeedSeconds = seedTimeHours > 0 ? seedTimeHours * 3600 : null
+
+  const mode = rules?.satisfactionMode
+  if (!mode) {
+    // Unverified entry: seed time alone, ratio ignored. Today's behaviour.
+    return requiredSeedSeconds === null ? null : { requiredSeedSeconds, requiredRatio: null, mode: "all" }
+  }
+
+  const minimumRatio = rules?.minimumRatio ?? 0
+  const requiredRatio = minimumRatio > 0 ? minimumRatio : null
+
+  // A declared mode over two absent thresholds is still no requirement.
+  if (requiredSeedSeconds === null && requiredRatio === null) return null
+
+  return { requiredSeedSeconds, requiredRatio, mode }
+}
+
+/** Fraction of the seed-time requirement met, 0..1. 1 when not required. */
+export function seedTimeProgress(seedingTime: number, req: SatisfactionRequirement): number {
+  if (req.requiredSeedSeconds === null) return 1
+  return Math.min(seedingTime / req.requiredSeedSeconds, 1)
+}
+
+/** Fraction of the ratio requirement met, 0..1. 1 when not required. */
+export function ratioProgress(ratio: number, req: SatisfactionRequirement): number {
+  if (req.requiredRatio === null) return 1
+  // A torrent that has downloaded nothing reports an infinite or negative ratio
+  // depending on the client. Neither is progress toward anything; treat only a
+  // finite, non-negative number as measurable.
+  if (!Number.isFinite(ratio) || ratio < 0) return 0
+  return Math.min(ratio / req.requiredRatio, 1)
+}
+
+/**
+ * How close a torrent is to being satisfied, 0..1.
+ *
+ * Under `any` this is the BEST of the routes: an either/or means you are as
+ * close as your nearest way out, and a torrent at 0.99 ratio is nearly done
+ * even with no seed time on the clock. Under `all` it is the WORST, because
+ * every requirement has to land and the laggard is what you are waiting on.
+ */
+export function satisfactionProgress(
+  torrent: { seedingTime: number; ratio: number },
+  req: SatisfactionRequirement
+): number {
+  const seed = seedTimeProgress(torrent.seedingTime, req)
+  const ratio = ratioProgress(torrent.ratio, req)
+  return req.mode === "any" ? Math.max(seed, ratio) : Math.min(seed, ratio)
+}
+
+export function isSatisfied(
+  torrent: { seedingTime: number; ratio: number },
+  req: SatisfactionRequirement
+): boolean {
+  return satisfactionProgress(torrent, req) >= 1
+}
+
+/**
+ * Seconds of seeding still owed, or null when seed time is not a route to
+ * satisfaction here (either the tracker does not require it, or the torrent has
+ * already satisfied the rule some other way).
+ */
+export function remainingSeedSeconds(
+  torrent: { seedingTime: number; ratio: number },
+  req: SatisfactionRequirement
+): number | null {
+  if (req.requiredSeedSeconds === null) return null
+  if (isSatisfied(torrent, req)) return null
+  return Math.max(req.requiredSeedSeconds - torrent.seedingTime, 0)
+}


### PR DESCRIPTION
## Summary

Satisfaction is currently decided by seed time alone:

```ts
// src/hooks/useTrackerTorrents.ts
const requiredSeedSeconds =
  rules?.seedTimeHours != null && rules.seedTimeHours > 0 ? rules.seedTimeHours * 3600 : null
const unsatisfiedTorrents = requiredSeedSeconds
  ? torrents.filter((t) => t.seedingTime < requiredSeedSeconds)
  : []
```

Ratio never enters it, so a tracker whose rule is an **either/or** cannot be expressed.
TorrentLeech states one outright — its wiki's H&R page is headed *"There are two ways for
you to give back to the community"*: seed a torrent to at least 1:1, **or** seed it for
the minimum time required for your user class.

## The bug this actually causes

Because there was nowhere to put the ratio half, `src/data/trackers/torrentleech.ts`
ships `seedTimeHours: 0`.

The consequence is **not** that TorrentLeech's torrents are judged leniently.
`requiredSeedSeconds` comes out `null`, and the **Unsatisfied Torrents table, the
unsatisfied count and the H&R-risk card all silently disappear** for that tracker. No
error, no empty state, nothing rendered at all — which is presumably why it has gone
unnoticed.

## The change

`rules.satisfactionMode: "any" | "all"` describes how the thresholds combine, and the
satisfaction logic moves out of the hook into pure, unit-testable functions in
`src/lib/satisfaction.ts`.

### The default is the load-bearing decision

**Ratio participates only for an entry that declares a mode** — not wherever
`minimumRatio` happens to be non-zero.

`minimumRatio` has always been in this registry as an **account-level** figure: it drives
the ratio-danger alert (`checkRatioBelowMinimum`) and the analytics chart baseline.
Reading it as a *per-torrent* requirement wherever it is set would silently re-interpret
all 55 entries that carry rules, against rules nobody has re-read — and on a tracker
whose real rule is seed-time-only, it would mark torrents satisfied that are not, which
is how hit and runs are earned.

So an entry without a mode behaves **exactly** as it does today, and `satisfactionMode`
doubles as a marker that a tracker's rules have been checked against its own wording.
Only `torrentleech.ts` declares one in this PR.

### Progress means something different under each mode

`satisfactionProgress` is `max(seedTime, ratio)` under `"any"` and `min(...)` under
`"all"`. Under an either/or you are as close as your **nearest** route out; under an
and, you are as far as your **laggard**.

That is not cosmetic — it drives the sort order of the Unsatisfied table. Sorting on
seed time alone buried a torrent sitting at 0.99 ratio, releasable within the hour,
beneath one with days on the clock and no way to clear at all.

The table gains a Ratio column when ratio is part of the rule, and **Remaining** now
names whichever route is nearer instead of always quoting seed time — and reports
nothing owed once the torrent has been satisfied by the other route, rather than
"6 days" for a torrent that is already free to go.

### A guard worth calling out

`ratioProgress` treats a **non-finite or negative** ratio as **zero** progress, not as
complete. Clients report `Infinity` for a torrent that has downloaded nothing, and
Transmission uses `-1` as a "not applicable" sentinel. Either one read naively as "far
past the requirement" would mark torrents satisfied that are not.

## The TorrentLeech entry

Filled in from the site's own wiki (`/doku.php/hnr`, `/doku.php/user_classes`):

```ts
rules: {
  minimumRatio: 1.0,
  seedTimeHours: 240,
  satisfactionMode: "any",
  loginIntervalDays: 0,
},
```

`240` is 10 days — the **Registered**-class requirement, and the longest on the site
(Power User 8d, Super User 7d, Extreme User 6d, TL GOD 4d, VIP none). Deliberately the
longest: a user's class is not knowable from a static registry, and over-seeding is the
safe direction to be wrong in. A user on a higher class sees their torrents held a
little longer than TorrentLeech requires, which costs them nothing but disk; the reverse
would cost them a hit and run.

FreeLeech is explicitly **not** exempt from either route, per the same wiki page.

## Not modelled, deliberately

TorrentLeech's rules also say seed time only accrues on **fully completed** torrents, and
that a partial download (≥10%) must reach 1:1 with no seed-time alternative. That is not
modelled explicitly because the client data already carries it: Transmission's
`secondsSeeding` only counts time after completion, so a partial torrent arrives with
effectively no seed time and falls to the ratio route on its own. Worth revisiting if a
client is ever added whose seeding clock behaves differently.

## Changes

| File | Action |
|------|--------|
| `src/lib/satisfaction.ts` | **Create** (the model, as pure functions) |
| `src/lib/satisfaction.test.ts` | **Create** (28 tests) |
| `src/data/tracker-registry.ts` | **Edit** (`TrackerRules.satisfactionMode`) |
| `src/data/trackers/torrentleech.ts` | **Edit** (`"any"`, `seedTimeHours: 240`) |
| `src/hooks/useTrackerTorrents.ts` | **Edit** (use the model; sort by progress) |
| `src/components/dashboard/torrents/UnsatisfiedTorrentsTable.tsx` | **Edit** (Ratio column, route-aware Remaining) |
| `src/components/dashboard/TorrentsTab.tsx` | **Edit** (gate on the resolved requirement) |
| `src/components/dashboard/__tests__/TorrentsTabEmptyStates.test.tsx` | **Edit** (fixture) |

**2 new files, 6 edited — 472 insertions, 27 deletions**
**Tests: 4261 passing (28 new) | TypeScript: clean | Biome: clean**

Verified end to end ✅ — the Unsatisfied table now populates for an entry that declares
`"any"`, where it previously rendered nothing, and every other tracker's table is unchanged.

---

## Disclosure

Written with AI assistance — the commit carries a `Co-Authored-By` trailer to that effect.

What that did and didn't mean here: this started from deploying the app and noticing that
one tracker's Unsatisfied table rendered nothing at all, then reading TorrentLeech's own
wiki to find out why. The rules encoded in `torrentleech.ts` are quoted from that wiki, not
inferred. The decision that ratio should only count for an entry that declares a mode is a
judgement call about not silently re-interpreting 55 existing entries, and it's the part
most worth arguing with me about.

I've read the diff and can walk through any part of it.

