### PR TITLE
fix(user-proxy): send a User-Agent on proxied tracker requests

### DIFF
--- a/src/lib/__tests__/tunnel-user-agent.test.ts
+++ b/src/lib/__tests__/tunnel-user-agent.test.ts
@@ -1,0 +1,63 @@
+// src/lib/__tests__/tunnel-user-agent.test.ts
+//
+// Regression cover for the proxied request path, which used to send no
+// User-Agent at all: node's https.request adds none, unlike fetch(). Trackers
+// that require the header answered 400 whenever the proxy was switched on and
+// worked with it off, which reads as a proxy fault rather than a missing header.
+
+import type { Agent } from "node:http"
+import { Readable } from "node:stream"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const requestMock = vi.hoisted(() => vi.fn())
+
+vi.mock("node:https", () => ({
+  default: { request: requestMock },
+}))
+
+import { proxyFetch } from "@/lib/tunnel"
+import { DEFAULT_USER_AGENT } from "@/lib/user-agent"
+
+function captureHeaders(): Record<string, string> {
+  return requestMock.mock.calls[0][0].headers
+}
+
+beforeEach(() => {
+  requestMock.mockReset()
+  requestMock.mockImplementation((_options: unknown, callback: (res: Readable) => void) => {
+    const res = Object.assign(Readable.from([Buffer.from('{"ok":true}')]), {
+      statusCode: 200,
+      statusMessage: "OK",
+    })
+    queueMicrotask(() => callback(res))
+    return { on: vi.fn(), write: vi.fn(), end: vi.fn(), destroy: vi.fn() }
+  })
+})
+
+const agent = {} as Agent
+
+describe("proxyFetch User-Agent", () => {
+  it("sends the app's User-Agent when the caller sets none", async () => {
+    await proxyFetch("https://example.test/api", agent)
+    expect(captureHeaders()["User-Agent"]).toBe(DEFAULT_USER_AGENT)
+  })
+
+  it("keeps a caller-supplied browser User-Agent", async () => {
+    const browserUa = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
+    await proxyFetch("https://example.test/api", agent, {
+      headers: { "User-Agent": browserUa },
+    })
+    const headers = captureHeaders()
+    expect(headers["User-Agent"]).toBe(browserUa)
+    expect(Object.keys(headers).filter((k) => k.toLowerCase() === "user-agent")).toHaveLength(1)
+  })
+
+  it("still sends other headers alongside it", async () => {
+    await proxyFetch("https://example.test/api", agent, {
+      headers: { Cookie: "session=placeholder" },
+    })
+    const headers = captureHeaders()
+    expect(headers.Cookie).toBe("session=placeholder")
+    expect(headers["User-Agent"]).toBe(DEFAULT_USER_AGENT)
+  })
+})

--- a/src/lib/__tests__/user-agent.test.ts
+++ b/src/lib/__tests__/user-agent.test.ts
@@ -1,0 +1,56 @@
+// src/lib/__tests__/user-agent.test.ts
+
+import { describe, expect, it } from "vitest"
+import { DEFAULT_USER_AGENT, withDefaultUserAgent } from "@/lib/user-agent"
+import packageJson from "../../../package.json"
+
+// ---------------------------------------------------------------------------
+// DEFAULT_USER_AGENT
+// ---------------------------------------------------------------------------
+
+describe("DEFAULT_USER_AGENT", () => {
+  it("identifies the app and its version", () => {
+    expect(DEFAULT_USER_AGENT).toBe(`tracker-tracker/${packageJson.version}`)
+  })
+
+  it("is a single header-safe token", () => {
+    expect(DEFAULT_USER_AGENT).not.toMatch(/[\r\n]/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// withDefaultUserAgent
+// ---------------------------------------------------------------------------
+
+describe("withDefaultUserAgent", () => {
+  it("adds a User-Agent when none is present", () => {
+    expect(withDefaultUserAgent({ Accept: "application/json" })).toEqual({
+      Accept: "application/json",
+      "User-Agent": DEFAULT_USER_AGENT,
+    })
+  })
+
+  it("adds a User-Agent when called with no headers at all", () => {
+    expect(withDefaultUserAgent()).toEqual({ "User-Agent": DEFAULT_USER_AGENT })
+  })
+
+  it("leaves a caller-supplied User-Agent alone", () => {
+    const browserUa = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
+    expect(withDefaultUserAgent({ "User-Agent": browserUa })).toEqual({ "User-Agent": browserUa })
+  })
+
+  // A scraping adapter must send back the exact UA its session cookie was
+  // issued to. Matching case-sensitively would emit a second header rather
+  // than replacing the first, which is the mismatch trackers fingerprint on.
+  it("matches an existing User-Agent case-insensitively", () => {
+    const result = withDefaultUserAgent({ "user-agent": "curl/8.0.1" })
+    expect(result).toEqual({ "user-agent": "curl/8.0.1" })
+    expect(Object.keys(result)).toHaveLength(1)
+  })
+
+  it("does not mutate the headers it was given", () => {
+    const headers = { Accept: "application/json" }
+    withDefaultUserAgent(headers)
+    expect(headers).toEqual({ Accept: "application/json" })
+  })
+})

--- a/src/lib/adapters/adapter-fetch.ts
+++ b/src/lib/adapters/adapter-fetch.ts
@@ -3,6 +3,7 @@
 import { classifyFetchError } from "@/lib/error-utils"
 import { ADAPTER_FETCH_TIMEOUT_MS } from "@/lib/limits"
 import { proxyFetch } from "@/lib/tunnel"
+import { withDefaultUserAgent } from "@/lib/user-agent"
 import type { FetchOptions } from "./types"
 
 async function adapterFetch<T>(
@@ -12,7 +13,7 @@ async function adapterFetch<T>(
   headers?: Record<string, string>,
   init?: { method?: "GET" | "POST"; body?: string }
 ): Promise<T> {
-  const mergedHeaders = { Accept: "application/json", ...headers }
+  const mergedHeaders = withDefaultUserAgent({ Accept: "application/json", ...headers })
   const method = init?.method ?? "GET"
   const body = method === "POST" ? (init?.body ?? "") : undefined
 

--- a/src/lib/adapters/mam.ts
+++ b/src/lib/adapters/mam.ts
@@ -21,7 +21,9 @@ interface MamJsonLoadResponse {
   username: string
   uid: number
   classname: string
-  ratio: number
+  // A display string, not a number: an account that has downloaded nothing
+  // reports "∞". Deliberately unused — see the ratio note in fetchStats.
+  ratio: string | number
   uploaded: string
   downloaded: string
   uploaded_bytes: number
@@ -139,8 +141,8 @@ export class MamAdapter implements TrackerAdapter {
       remoteUserId: data.uid,
       uploadedBytes: uploaded,
       downloadedBytes: downloaded,
-      // Derived from byte totals. MAM's own ratio field encoding for a
-      // zero-download account is undocumented and parsed to 0.
+      // Derived from byte totals rather than read from data.ratio, which is a
+      // display string ("∞" for an account that has downloaded nothing).
       ratio: computeRatio(uploaded, downloaded),
       bufferBytes: computeBufferBytes(uploaded, downloaded),
       seedingCount,

--- a/src/lib/tunnel.ts
+++ b/src/lib/tunnel.ts
@@ -10,6 +10,7 @@ import { SocksProxyAgent } from "socks-proxy-agent"
 
 import { decrypt } from "@/lib/crypto"
 import { log } from "@/lib/logger"
+import { withDefaultUserAgent } from "@/lib/user-agent"
 
 export type ProxyType = "socks5" | "http" | "https"
 
@@ -87,13 +88,13 @@ export function proxyFetch(
         path: parsed.pathname + parsed.search,
         method,
         agent,
-        headers: {
+        headers: withDefaultUserAgent({
           Accept: "application/json",
           ...(body === undefined
             ? {}
             : { "Content-Length": String(Buffer.byteLength(body, "utf8")) }),
           ...options.headers,
-        },
+        }),
         timeout: timeoutMs,
       },
       (res) => {

--- a/src/lib/user-agent.ts
+++ b/src/lib/user-agent.ts
@@ -1,0 +1,34 @@
+// src/lib/user-agent.ts
+//
+// Functions: withDefaultUserAgent
+
+import packageJson from "../../package.json"
+
+/**
+ * Sent on every outbound tracker request that does not already carry a
+ * User-Agent of its own.
+ *
+ * Some trackers reject a request with no User-Agent header outright, before
+ * they look at the session cookie — MyAnonaMouse answers `400 Bad request`
+ * ("Your browser sent an invalid request"), which is indistinguishable from a
+ * malformed request until you compare it against the same call with a header
+ * attached. Identifying ourselves is also simply better manners toward a
+ * tracker operator reading their access log.
+ */
+export const DEFAULT_USER_AGENT = `tracker-tracker/${packageJson.version}`
+
+/**
+ * Adds {@link DEFAULT_USER_AGENT} unless the caller set one.
+ *
+ * The check is case-insensitive on purpose: adapters that scrape with a
+ * copied browser session send `User-Agent`, and a second header differing only
+ * in case would be sent alongside it rather than replacing it. Those adapters
+ * must keep the exact UA the cookie was issued to — a mismatch is what the
+ * tracker's session fingerprinting looks for.
+ */
+export function withDefaultUserAgent(
+  headers: Record<string, string> = {}
+): Record<string, string> {
+  const hasUserAgent = Object.keys(headers).some((key) => key.toLowerCase() === "user-agent")
+  return hasUserAgent ? headers : { ...headers, "User-Agent": DEFAULT_USER_AGENT }
+}


### PR DESCRIPTION

## Summary

The proxied and unproxied request paths do not send the same headers, and one tracker
rejects the difference.

`adapterFetch` branches on whether a proxy agent is configured
(`src/lib/adapters/adapter-fetch.ts`). Without one it calls `fetch()`, which sets a
User-Agent of its own. With one it goes through `proxyFetch` → `https.request`
(`src/lib/tunnel.ts`), and **node sends no User-Agent there at all**.

MyAnonaMouse rejects a request with no User-Agent outright:

```
HTTP 400
<html><body><h1>400 Bad request</h1>
Your browser sent an invalid request.
</body></html>
```

So with a proxy configured, every MAM poll fails, and it fails in the most misleading way
available.

## Why this is worth more than the two lines it costs

**The 400 arrives before the session cookie is read**, which makes a header problem look
exactly like a credential problem.

Measured against the live endpoint, no valid session involved:

| Request | Response |
|---|---|
| User-Agent present, no cookie | `403` — *"Invalid/missing cookie"* |
| User-Agent present, junk cookie | `403` — same |
| **No User-Agent**, junk cookie | **`400 Bad request`** |
| **No User-Agent**, no cookie | **`400 Bad request`** |

Every diagnostic instinct the error invites is wrong. The user rotates the `mam_id` and
nothing changes. They generate another and it fails identically. They try it from a
different network and it fails identically, because the header is missing regardless of
where the request comes from. Meanwhile the same credential works fine in a browser, and
works in the app the moment the proxy is switched off — which points the finger at the
proxy, the one component that is behaving correctly.

The tracker's own logs are no help either: it never gets far enough to record a session.

It is also not MAM-specific in principle. Any tracker that requires a User-Agent — a
common enough WAF rule — is unreachable through this app's proxy path today, and would
present the same way.

## The change

`src/lib/user-agent.ts` exports a default of `tracker-tracker/<version>`, read from
`package.json`, and a `withDefaultUserAgent()` helper. Both request paths apply it.

Three decisions in it worth stating:

**A caller-supplied User-Agent always wins.** The adapters that authenticate with a
copied browser session (IPTorrents, the AvistaZ family, and anything else going through
`html-fetch`) must send back the exact UA their cookie was issued to; a mismatch is what
session fingerprinting looks for. Those are untouched.

**The match is case-insensitive.** Comparing case-sensitively would not overwrite a
caller's `user-agent`, it would emit a *second* header next to it — which is the same
mismatch, arrived at by a different route. There is a test for this specifically.

**It is applied to both paths, not just the broken one.** The unproxied path already sent
something, so only the proxied path was failing. But the asymmetry *is* the bug: a request
that changes shape depending on whether a proxy is configured is what made this so hard to
place. Both paths now send the same identifying string, which is also better manners toward
a tracker operator reading their access log than node's default.

## Also in here

`MamJsonLoadResponse.ratio` was typed `number`. It is a display string — an account that
has downloaded nothing reports `"∞"`. Corrected to `string | number`, with a comment
explaining that the adapter deliberately derives ratio from the byte totals instead. No
behaviour change; the field was already unused.

## Changes

| File | Action |
|------|--------|
| `src/lib/user-agent.ts` | **Create** (the default and the helper) |
| `src/lib/__tests__/user-agent.test.ts` | **Create** (7 tests) |
| `src/lib/__tests__/tunnel-user-agent.test.ts` | **Create** (3 tests, regression cover on the proxied path) |
| `src/lib/tunnel.ts` | **Edit** (apply in `proxyFetch`) |
| `src/lib/adapters/adapter-fetch.ts` | **Edit** (apply on the direct path) |
| `src/lib/adapters/mam.ts` | **Edit** (`ratio` type) |

**3 new files, 3 edited — 163 insertions, 6 deletions**
**Tests: 4243 passing (10 new) | TypeScript: clean | Biome: clean**

Verified against a live account ✅ — the 400/403 table above is measured, not inferred, and
with the fix in place the tracker polls successfully where it previously could not be
authenticated at all.

---

## Disclosure

Written with AI assistance — the commit carries a `Co-Authored-By` trailer to that effect.

What that did and didn't mean here: the fix is two lines, and finding it was the work. It
came from bisecting an unhelpful error against the live endpoint — sending the same request
with and without a header until the 400 turned into a 403 — rather than from reading the
source and reasoning about what might be wrong. The table above is that experiment's output.

I've read the diff and can walk through any part of it.
