### PR TITLE
feat(security): allow specific origins to frame the UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,6 @@ TZ=America/Chicago
 # LOG_LEVEL=debug
 # POSTGRES_DB=tracker_tracker
 
+# Origins allowed to embed the UI in an iframe (Organizr, Homarr, Heimdall).
+# Space- or comma-separated. Unset means no origin may frame the app.
+# ALLOWED_FRAME_ANCESTORS=https://organizr.example.com

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ pnpm dev
 | `POSTGRES_DB`       | No       | `tracker_tracker` | Database name                                       |
 | `DATABASE_URL`      | No\*     | _(auto-built)_    | Override to use an external Postgres instance       |
 | `SECURE_COOKIES`    | No       | _(auto)_          | Set `true` for HTTPS. Auto-enabled by `BASE_URL`.   |
+| `ALLOWED_FRAME_ANCESTORS` | No   | _(unset)_       | Origins allowed to embed the UI in an iframe, space- or comma-separated (e.g. `https://organizr.example.com`). Unset means no origin may frame the app. Only well-formed origins are accepted; anything else is ignored and the default deny applies. |
 | `DISABLE_LOGIN_LOCKOUT` | No   | _(unset)_         | Set `true` to stop failed-attempt lockouts being enforced, for when you have locked yourself out, because the in-app toggle sits behind the login you cannot reach. Also suppresses enforcement on the backup-restore password check. Failed attempts are still counted, and a successful login clears them. Unset it once you are back in. |
 
 \* Set either `POSTGRES_PASSWORD` (bundled DB) or `DATABASE_URL` (external DB).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
       # LOG_LEVEL: ${LOG_LEVEL} # optional, defaults to 'info'
       # LOG_FILE: /data/logs/tracker-tracker.log # optional
       BASE_URL: ${BASE_URL:-} # optional, i.e https://trackertracker.example.com
+      # Origins allowed to embed the UI in an iframe, e.g. https://organizr.example.com
+      ALLOWED_FRAME_ANCESTORS: ${ALLOWED_FRAME_ANCESTORS:-}
       # SECURE_COOKIES: ${SECURE_COOKIES:-} # set to 'true' if serving over HTTPS
       # DISABLE_LOGIN_LOCKOUT: "true" # recovery switch that stops failed-login lockouts from being
       #   enforced. The in-app lockout toggle sits behind the login you cannot reach, so this is

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,10 @@ import type { NextConfig } from "next"
 
 const securityHeaders = [
   { key: "X-Content-Type-Options", value: "nosniff" },
-  { key: "X-Frame-Options", value: "DENY" },
+  // X-Frame-Options is deliberately NOT here. next.config headers() is evaluated at
+  // build time and frozen into .next/routes-manifest.json, so a header set here can
+  // never respond to an environment variable in a prebuilt image. The framing headers
+  // are applied at request time in src/proxy.ts instead — see src/lib/frame-security.ts.
   { key: "X-XSS-Protection", value: "0" },
   { key: "X-DNS-Prefetch-Control", value: "off" },
   { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },

--- a/scripts/security-audit.ts
+++ b/scripts/security-audit.ts
@@ -82,9 +82,12 @@ const NO_AUTH_ROUTES = new Set([
 // - getSession() from auth.ts (used by logout)
 const AUTH_PATTERNS = [/\bauthenticate\s*\(/, /\bgetSession\s*\(/, /\brequireAuth\s*\(/]
 
+// X-Frame-Options is deliberately absent: it moved to the runtime middleware so it
+// can respond to CLICKJACKING_PROTECTION, and is verified by checkFrameSecurity()
+// against src/lib/frame-security.ts instead. A substring match on next.config.ts
+// would be satisfied by a comment mentioning the header, which is not a check.
 const REQUIRED_HEADERS = [
   "X-Content-Type-Options",
-  "X-Frame-Options",
   "X-XSS-Protection",
   "X-DNS-Prefetch-Control",
   "Referrer-Policy",
@@ -464,6 +467,61 @@ function checkSecurityHeaders(): CheckResult {
   return {
     id: "security-headers",
     name: "Security headers in next.config.ts",
+    severity: "critical",
+    status: findings.length === 0 ? "pass" : "fail",
+    findings,
+  }
+}
+
+// ── Check 4b: Framing headers ───────────────────────────────────────────
+
+// Assert the *default* stays closed: DENY plus frame-ancestors 'none', which is the
+// behaviour the hardcoded header used to give. A regression here would silently open
+// framing for every deployment that has not configured an allow-list, so it is
+// checked rather than left to the unit tests alone.
+// Strip comments before matching. Without this the check is satisfied by prose that
+// merely mentions a header — which is how the old next.config.ts check behaved, and
+// is not a check at all.
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1")
+}
+
+function checkFrameSecurity(): CheckResult {
+  const findings: Finding[] = []
+  const file = path.resolve(ROOT, "src/lib/frame-security.ts")
+
+  if (!fs.existsSync(file)) {
+    findings.push({ file: "src/lib/frame-security.ts", detail: "Module not found" })
+  } else {
+    const content = stripComments(fs.readFileSync(file, "utf8"))
+    for (const needle of ["X-Frame-Options", "DENY", "frame-ancestors 'none'"]) {
+      if (!content.includes(needle)) {
+        findings.push({
+          file: "src/lib/frame-security.ts",
+          detail: `Missing framing header value: ${needle}`,
+        })
+      }
+    }
+  }
+
+  const proxyFile = path.resolve(ROOT, "src/proxy.ts")
+  if (!fs.existsSync(proxyFile)) {
+    findings.push({ file: "src/proxy.ts", detail: "Middleware not found" })
+  } else if (
+    // The import alone must not satisfy this — require an actual call site.
+    !/applyFrameSecurityHeaders\s*\(/.test(
+      stripComments(fs.readFileSync(proxyFile, "utf8")).replace(/^\s*import[\s\S]*?$/gm, "")
+    )
+  ) {
+    findings.push({
+      file: "src/proxy.ts",
+      detail: "Middleware does not apply the framing headers",
+    })
+  }
+
+  return {
+    id: "frame-security",
+    name: "Framing headers applied at runtime",
     severity: "critical",
     status: findings.length === 0 ? "pass" : "fail",
     findings,
@@ -2527,6 +2585,7 @@ function runAudit(changedFiles?: string[]): AuditOutput {
     checkDangerousFunctions(absChangedFiles),
     checkHardcodedSecrets(absChangedFiles),
     checkSecurityHeaders(),
+    checkFrameSecurity(),
     checkCookieSecurity(),
     checkSensitiveFieldExposure(),
     checkEnvFiles(),

--- a/src/lib/frame-security.test.ts
+++ b/src/lib/frame-security.test.ts
@@ -1,0 +1,166 @@
+// src/lib/frame-security.test.ts
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  ALLOWED_FRAME_ANCESTORS_ENV,
+  applyFrameSecurityHeaders,
+  CSP_HEADER,
+  FRAME_OPTIONS_HEADER,
+  frameSecurityHeaders,
+  parseAllowedFrameAncestors,
+} from "./frame-security"
+
+describe("parseAllowedFrameAncestors", () => {
+  it("returns nothing for unset, empty, or whitespace-only values", () => {
+    for (const raw of [undefined, "", "   ", "\n\t"]) {
+      expect(parseAllowedFrameAncestors(raw).allowed).toEqual([])
+    }
+  })
+
+  it("accepts a single https origin", () => {
+    expect(parseAllowedFrameAncestors("https://dash.example.com").allowed).toEqual([
+      "https://dash.example.com",
+    ])
+  })
+
+  it("accepts space-separated and comma-separated lists", () => {
+    const expected = ["https://a.example.com", "https://b.example.com"]
+    expect(parseAllowedFrameAncestors("https://a.example.com https://b.example.com").allowed).toEqual(expected)
+    expect(parseAllowedFrameAncestors("https://a.example.com,https://b.example.com").allowed).toEqual(expected)
+  })
+
+  it("accepts an Appsmith-style value containing 'self' verbatim", () => {
+    const { allowed, rejected } = parseAllowedFrameAncestors("'self' https://dash.example.com")
+    expect(allowed).toEqual(["https://dash.example.com"])
+    expect(rejected).toEqual([])
+  })
+
+  it("accepts ports, http, and subdomain wildcards", () => {
+    expect(parseAllowedFrameAncestors("https://dash.example.com:8443").allowed).toHaveLength(1)
+    expect(parseAllowedFrameAncestors("http://dash.lan").allowed).toHaveLength(1)
+    expect(parseAllowedFrameAncestors("https://*.example.com").allowed).toHaveLength(1)
+  })
+
+  it("de-duplicates repeated origins", () => {
+    expect(
+      parseAllowedFrameAncestors("https://a.example.com https://a.example.com").allowed
+    ).toEqual(["https://a.example.com"])
+  })
+
+  // The env var is interpolated into a response header, so anything that is not
+  // an origin must be dropped rather than sanitized into something plausible.
+  it.each([
+    ["a bare wildcard", "*"],
+    ["a smuggled second directive", "https://x.example.com;script-src 'unsafe-inline'"],
+    ["a CSP keyword", "'unsafe-inline'"],
+    ["the none keyword", "'none'"],
+    ["a data URI", "data:"],
+    ["a blob URI", "blob:"],
+    ["a scheme-relative host", "//example.com"],
+    ["a bare hostname", "example.com"],
+    ["a javascript URI", "javascript:alert(1)"],
+    ["a path", "https://example.com/embed"],
+    ["an over-long port", "https://example.com:123456"],
+  ])("rejects %s", (_label, value) => {
+    const { allowed, rejected } = parseAllowedFrameAncestors(value)
+    expect(allowed).toEqual([])
+    expect(rejected.length).toBeGreaterThan(0)
+  })
+
+  // A CRLF payload cannot inject a header: the split consumes the newline, the
+  // origin is validated on its own, and the junk after it is rejected. Asserted as
+  // the output property rather than by rejecting the whole value.
+  it("cannot be used to inject a second header", () => {
+    const { allowed, rejected } = parseAllowedFrameAncestors("https://example.com\r\nX-Evil: 1")
+    expect(allowed).toEqual(["https://example.com"])
+    expect(rejected).toEqual(["X-Evil:", "1"])
+    for (const origin of allowed) {
+      expect(origin).not.toMatch(/[\r\n]/)
+    }
+  })
+
+  it("keeps the valid origins and reports the invalid ones alongside", () => {
+    const { allowed, rejected } = parseAllowedFrameAncestors("https://good.example.com nonsense")
+    expect(allowed).toEqual(["https://good.example.com"])
+    expect(rejected).toEqual(["nonsense"])
+  })
+})
+
+describe("frameSecurityHeaders", () => {
+  it("denies framing by default, matching the previous hardcoded behaviour", () => {
+    expect(frameSecurityHeaders(undefined)).toEqual({
+      [FRAME_OPTIONS_HEADER]: "DENY",
+      [CSP_HEADER]: "frame-ancestors 'none'",
+    })
+  })
+
+  it("fails closed when every configured origin is invalid", () => {
+    expect(frameSecurityHeaders("* javascript:alert(1)")).toEqual({
+      [FRAME_OPTIONS_HEADER]: "DENY",
+      [CSP_HEADER]: "frame-ancestors 'none'",
+    })
+  })
+
+  it("emits a scoped frame-ancestors for a configured origin", () => {
+    expect(frameSecurityHeaders("https://dash.example.com")).toEqual({
+      [CSP_HEADER]: "frame-ancestors 'self' https://dash.example.com",
+    })
+  })
+
+  it("omits X-Frame-Options once an allow-list exists, rather than downgrading it", () => {
+    const headers = frameSecurityHeaders("https://dash.example.com")
+    expect(headers[FRAME_OPTIONS_HEADER]).toBeUndefined()
+  })
+
+  it("never emits a policy that allows all origins", () => {
+    for (const raw of ["*", "https://*", "'self' *", undefined, ""]) {
+      const csp = frameSecurityHeaders(raw)[CSP_HEADER]
+      expect(csp).not.toMatch(/frame-ancestors[^;]*\*(\s|$)/)
+    }
+  })
+
+  it("constrains framing only, leaving other CSP directives unrestricted", () => {
+    const csp = frameSecurityHeaders("https://dash.example.com")[CSP_HEADER]
+    expect(csp?.startsWith("frame-ancestors ")).toBe(true)
+    expect(csp).not.toContain(";")
+  })
+})
+
+describe("applyFrameSecurityHeaders", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it("sets the deny pair on a bare Headers instance", () => {
+    const headers = new Headers()
+    applyFrameSecurityHeaders(headers)
+    expect(headers.get(FRAME_OPTIONS_HEADER)).toBe("DENY")
+    expect(headers.get(CSP_HEADER)).toBe("frame-ancestors 'none'")
+  })
+
+  it("reads the allow-list from the environment", () => {
+    vi.stubEnv(ALLOWED_FRAME_ANCESTORS_ENV, "https://dash.example.com")
+    const headers = new Headers()
+    applyFrameSecurityHeaders(headers)
+    expect(headers.get(CSP_HEADER)).toBe("frame-ancestors 'self' https://dash.example.com")
+    expect(headers.get(FRAME_OPTIONS_HEADER)).toBeNull()
+  })
+
+  // The whole point of the allow-list is defeated if a DENY survives underneath it.
+  it("clears a pre-existing X-Frame-Options when an allow-list is configured", () => {
+    vi.stubEnv(ALLOWED_FRAME_ANCESTORS_ENV, "https://dash.example.com")
+    const headers = new Headers({ [FRAME_OPTIONS_HEADER]: "DENY" })
+    applyFrameSecurityHeaders(headers)
+    expect(headers.get(FRAME_OPTIONS_HEADER)).toBeNull()
+  })
+
+  it("leaves unrelated security headers alone", () => {
+    const headers = new Headers({ "X-Content-Type-Options": "nosniff" })
+    applyFrameSecurityHeaders(headers)
+    expect(headers.get("X-Content-Type-Options")).toBe("nosniff")
+  })
+})

--- a/src/lib/frame-security.ts
+++ b/src/lib/frame-security.ts
@@ -1,0 +1,96 @@
+// src/lib/frame-security.ts
+
+/**
+ * Framing policy, modelled on Appsmith's `APPSMITH_ALLOWED_FRAME_ANCESTORS`
+ * (deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs).
+ *
+ * The problem this solves: a self-hosted dashboard (Organizr, Homarr, Heimdall)
+ * lives on a different origin to this app, and `X-Frame-Options` cannot express
+ * "that origin may frame me". Its `ALLOW-FROM` form is unsupported in every
+ * current browser, leaving only DENY and SAMEORIGIN. CSP `frame-ancestors` is
+ * the modern directive that does take an origin list, and it supersedes
+ * `X-Frame-Options` wherever both are understood.
+ *
+ * Default is unchanged from hardcoded DENY: no origin may frame the app. Naming
+ * an origin narrows the exception to that origin — it never opens framing to all.
+ * There is deliberately no "off" switch.
+ */
+
+export const FRAME_OPTIONS_HEADER = "X-Frame-Options"
+export const CSP_HEADER = "Content-Security-Policy"
+export const ALLOWED_FRAME_ANCESTORS_ENV = "ALLOWED_FRAME_ANCESTORS"
+
+/**
+ * A single origin: scheme, host, optional port. Optionally a `*.` subdomain
+ * wildcard, which CSP supports and which Appsmith also allows.
+ *
+ * Everything else is rejected, which is what keeps the env var out of the header
+ * as arbitrary text. A bare `*`, `data:`, `blob:`, a `'unsafe-*'` keyword, a
+ * second CSP directive smuggled in after a `;`, or stray whitespace all fail
+ * this and are dropped rather than sanitized into something plausible.
+ */
+const ORIGIN_PATTERN = /^https?:\/\/(\*\.)?[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*(:\d{1,5})?$/i
+
+export interface FramePolicy {
+  /** Origins permitted to frame the app, beyond the app's own origin. */
+  allowed: string[]
+  /** Tokens that were rejected, so the caller can warn rather than fail silently. */
+  rejected: string[]
+}
+
+export function parseAllowedFrameAncestors(raw: string | undefined): FramePolicy {
+  const allowed: string[] = []
+  const rejected: string[] = []
+
+  for (const token of (raw ?? "").split(/[\s,]+/)) {
+    if (token === "") continue
+    // 'self' is implied and always emitted; accepting it here keeps the Appsmith
+    // style value ("'self' https://dash.example.com") working verbatim.
+    if (token === "'self'") continue
+    if (ORIGIN_PATTERN.test(token)) {
+      if (!allowed.includes(token)) allowed.push(token)
+    } else {
+      rejected.push(token)
+    }
+  }
+
+  return { allowed, rejected }
+}
+
+/**
+ * Framing headers for the current configuration.
+ *
+ * With no configured origins the app is unframeable, and both headers say so —
+ * `X-Frame-Options` for browsers that predate `frame-ancestors`, and the CSP for
+ * everything current.
+ *
+ * With origins configured, `X-Frame-Options` is omitted rather than downgraded:
+ * it cannot express the allow-list, and leaving `DENY` in place would be honoured
+ * by any client that does not understand CSP, contradicting the policy. The CSP
+ * is then the single source of truth, and it is narrower than SAMEORIGIN would be.
+ */
+export function frameSecurityHeaders(
+  raw: string | undefined = process.env[ALLOWED_FRAME_ANCESTORS_ENV]
+): Record<string, string> {
+  const { allowed } = parseAllowedFrameAncestors(raw)
+
+  if (allowed.length === 0) {
+    return {
+      [FRAME_OPTIONS_HEADER]: "DENY",
+      [CSP_HEADER]: "frame-ancestors 'none'",
+    }
+  }
+
+  return {
+    [CSP_HEADER]: `frame-ancestors 'self' ${allowed.join(" ")}`,
+  }
+}
+
+export function applyFrameSecurityHeaders(headers: Headers): void {
+  // Delete first: a configured allow-list must not leave a stale DENY behind.
+  headers.delete(FRAME_OPTIONS_HEADER)
+  headers.delete(CSP_HEADER)
+  for (const [key, value] of Object.entries(frameSecurityHeaders())) {
+    headers.set(key, value)
+  }
+}

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,7 +1,7 @@
 // src/proxy.test.ts
 
 import { NextRequest } from "next/server"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { proxy } from "./proxy"
 
 vi.mock("@/lib/cookie-security", () => ({
@@ -81,5 +81,71 @@ describe("auth middleware", () => {
   it("allows health check without authentication", () => {
     const response = proxy(new NextRequest("http://localhost/api/health"))
     expect(response.status).toBe(200)
+  })
+})
+
+describe("framing headers", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  // Every branch of proxy() must carry the headers. A response leaving through a
+  // path nobody remembered to cover is unprotected, so each is asserted separately
+  // rather than trusting one representative case.
+  const paths: Array<[string, string, string | undefined]> = [
+    ["a public route", "http://localhost/api/auth/status", undefined],
+    ["an unauthenticated API route", "http://localhost/api/trackers", undefined],
+    ["a login redirect", "http://localhost/settings", undefined],
+    [
+      "an authenticated request",
+      "http://localhost/api/trackers",
+      "tt_session=session-token; tt_max_age=1800",
+    ],
+  ]
+
+  const call = (url: string, cookie?: string) =>
+    proxy(new NextRequest(url, cookie ? { headers: { cookie } } : undefined))
+
+  for (const [label, url, cookie] of paths) {
+    it(`denies framing by default on ${label}`, () => {
+      const response = call(url, cookie)
+
+      expect(response.headers.get("X-Frame-Options")).toBe("DENY")
+      expect(response.headers.get("Content-Security-Policy")).toBe("frame-ancestors 'none'")
+    })
+
+    it(`scopes framing to the configured origin on ${label}`, () => {
+      vi.stubEnv("ALLOWED_FRAME_ANCESTORS", "https://dash.example.com")
+      const response = call(url, cookie)
+
+      expect(response.headers.get("Content-Security-Policy")).toBe(
+        "frame-ancestors 'self' https://dash.example.com"
+      )
+      expect(response.headers.get("X-Frame-Options")).toBeNull()
+    })
+  }
+
+  it("still redirects and still returns 401 with an allow-list configured", async () => {
+    vi.stubEnv("ALLOWED_FRAME_ANCESTORS", "https://dash.example.com")
+
+    expect(call("http://localhost/settings").headers.get("location")).toBe(
+      "http://localhost/login"
+    )
+
+    const api = call("http://localhost/api/trackers")
+    expect(api.status).toBe(401)
+    await expect(api.json()).resolves.toEqual({ error: "Unauthorized" })
+  })
+
+  it("falls back to deny when the configured value is junk", () => {
+    vi.stubEnv("ALLOWED_FRAME_ANCESTORS", "*")
+    const response = call("http://localhost/login")
+
+    expect(response.headers.get("X-Frame-Options")).toBe("DENY")
+    expect(response.headers.get("Content-Security-Policy")).toBe("frame-ancestors 'none'")
   })
 })

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,7 @@
 // src/proxy.ts
 import { type NextRequest, NextResponse } from "next/server"
 import { shouldSecureCookies } from "@/lib/cookie-security"
+import { applyFrameSecurityHeaders } from "@/lib/frame-security"
 
 const PUBLIC_EXACT = ["/login", "/setup", "/api/health"]
 const PUBLIC_PREFIX = ["/api/auth/", "/api/verify-report", "/_next/", "/img/", "/favicon"]
@@ -11,17 +12,24 @@ const MAX_COOKIE_AGE = 60 * 60 * 24 * 30 // 30-day hard cap
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
 
+  // Applied to every response below, including the public and unauthenticated
+  // paths — a login page is exactly the kind of page clickjacking targets.
+  const withFrameHeaders = <T extends { headers: Headers }>(response: T): T => {
+    applyFrameSecurityHeaders(response.headers)
+    return response
+  }
+
   if (PUBLIC_EXACT.includes(pathname) || PUBLIC_PREFIX.some((p) => pathname.startsWith(p))) {
-    return NextResponse.next()
+    return withFrameHeaders(NextResponse.next())
   }
 
   const session = request.cookies.get(SESSION_COOKIE)
 
   if (!session) {
     if (pathname.startsWith("/api/")) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      return withFrameHeaders(NextResponse.json({ error: "Unauthorized" }, { status: 401 }))
     }
-    return NextResponse.redirect(new URL("/login", request.url))
+    return withFrameHeaders(NextResponse.redirect(new URL("/login", request.url)))
   }
 
   // Sliding window: re-set both cookies with a fresh maxAge on every
@@ -49,7 +57,7 @@ export function proxy(request: NextRequest) {
     })
   }
 
-  return response
+  return withFrameHeaders(response)
 }
 
 export const config = {


### PR DESCRIPTION
## Summary

`X-Frame-Options` is hardcoded to `DENY` in `next.config.ts`, so the UI cannot be embedded
by a self-hosted dashboard — [Organizr](https://github.com/causefx/Organizr),
[Homarr](https://github.com/ajnart/homarr), [Heimdall](https://github.com/linuxserver/Heimdall) —
and no setting changes it.

The header itself is the reason this needs a CSP rather than a looser `X-Frame-Options`:
its allow-list form, `ALLOW-FROM`, is
[unsupported in every current browser](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options#allow-from_origin),
leaving only `DENY` and `SAMEORIGIN`. Neither can express "this one dashboard may frame me".
CSP [`frame-ancestors`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/frame-ancestors)
can, and [supersedes `X-Frame-Options`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options)
wherever both are understood.

So this adds `ALLOWED_FRAME_ANCESTORS`, which narrows the existing deny to named origins.
**It does not add a way to turn the protection off.**

## Modelled on Appsmith

Rather than invent a shape, this follows [Appsmith](https://github.com/appsmithorg/appsmith)'s
[`APPSMITH_ALLOWED_FRAME_ANCESTORS`](https://docs.appsmith.com/getting-started/setup/instance-configuration/frame-ancestors),
implemented in
[`deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs`](https://github.com/appsmithorg/appsmith/blob/release/deploy/docker/fs/opt/appsmith/caddy-reconfigure.mjs):

```js
const frameAncestorsPolicy = (process.env.APPSMITH_ALLOWED_FRAME_ANCESTORS || "'self'")
  .replace(/;.*$/, "")
...
Content-Security-Policy "frame-ancestors ${frameAncestorsPolicy}"
```

Same variable shape and same space-separated value, so a value written for Appsmith —
including a leading `'self'` — works here verbatim.

One deliberate difference: Appsmith guards CSP injection by truncating at the first `;`.
That stops a smuggled second directive but still lets arbitrary text reach the header, so
this validates each token against an origin pattern instead and drops anything else.

## Default is unchanged

| `ALLOWED_FRAME_ANCESTORS` | `X-Frame-Options` | `Content-Security-Policy` |
|---|---|---|
| unset | `DENY` | `frame-ancestors 'none'` |
| `https://organizr.example.com` | _omitted_ | `frame-ancestors 'self' https://organizr.example.com` |
| junk (`*`, `javascript:…`) | `DENY` | `frame-ancestors 'none'` |

Unset behaves exactly as the hardcoded header did. The added `frame-ancestors 'none'`
closes a real gap: the app previously sent only the deprecated header and no CSP at all.

**Invalid input fails closed.** A typo'd origin does not silently open framing — it is
dropped, and if nothing valid remains the policy falls back to deny.

**`X-Frame-Options` is omitted, not downgraded**, once an allow-list exists. Downgrading it
to `SAMEORIGIN` would not help — a dashboard on another subdomain is a different origin —
and a surviving `DENY` would be honoured by any client that ignores CSP, contradicting the
policy the CSP states.

## What is rejected

The variable is interpolated into a response header, so anything that is not an origin is
dropped rather than sanitized into something plausible: a bare `*`, `data:`, `blob:`,
`javascript:` URIs, CSP keywords like `'unsafe-inline'`, a scheme-relative `//host`, a bare
hostname, a path, an out-of-range port, and a second directive after a `;`. Ports and `*.`
subdomain wildcards are accepted.

A CRLF payload cannot inject a header — the token split consumes the newline, the origin is
validated alone, and only validated tokens are re-joined. There is a test asserting that
output property rather than assuming it.

## Why `src/proxy.ts` and not `next.config.ts`

The obvious implementation — read the env var inside `headers()` — does not work for anyone
running the published image, which is worth recording because it is invisible from the
source. [`headers()`](https://nextjs.org/docs/app/api-reference/config/next-config-js/headers)
is evaluated at build time and frozen into `.next/routes-manifest.json`. From a running
container before this change:

```json
{ "key": "X-Frame-Options", "value": "DENY" }
```

An env var read there is baked in at `docker build` and ignored at runtime. So the framing
headers move to `src/proxy.ts`, which already reads env per-request for
`shouldSecureCookies()`. The remaining static headers stay in `next.config.ts` untouched.

Every branch of `proxy()` applies them, including the unauthenticated 401 and the login
redirect — a login page is exactly what clickjacking targets. Each branch is asserted
separately, so a future return path added without them fails the suite.

One consequence: `proxy.ts`'s matcher excludes `_next/static`, `_next/image` and the logo
assets, so those no longer carry `X-Frame-Options`. They are static images with no UI to
hijack.

## The security audit needed a real check

`scripts/security-audit.ts` asserted the headers by substring-matching `next.config.ts`.
After the header moved, a comment mentioning it still satisfied that match and the audit
reported 38/38 — it was matching prose.

The check is rewritten rather than worked around: a new `checkFrameSecurity()` asserts the
module still emits `DENY` and `frame-ancestors 'none'` by default and that `proxy.ts`
actually calls the helper, with comments stripped and the import line excluded so neither a
comment nor a bare `import` can satisfy it.

Confirmed by tampering: opening the default policy, or deleting the call site, each turn the
check red, and it returns green on restore. Total goes 38 → 39.

## Verified at runtime

Against a running dev server, not only unit tests. All three rows of the table above were
checked by starting the app with that configuration and reading the response headers; the
`X-Content-Type-Options: nosniff` header stayed present throughout, confirming the change
touches only the framing pair.

The emitted CSP contains `frame-ancestors` and nothing else.
[Directives absent from a policy are unrestricted](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy),
so this constrains framing only and does not introduce a
`default-src`/`script-src` policy that would need maintaining alongside the UI.

## Changes

| File | Action |
|------|--------|
| `src/lib/frame-security.ts` | **Create** (parsing, validation, headers) |
| `src/lib/frame-security.test.ts` | **Create** (29 tests) |
| `src/proxy.ts` | **Edit** (apply on every branch) |
| `src/proxy.test.ts` | **Edit** (10 tests, per return path) |
| `next.config.ts` | **Edit** (remove the baked `X-Frame-Options`) |
| `scripts/security-audit.ts` | **Edit** (real check, +1 total) |
| `README.md`, `.env.example`, `docker-compose.yml` | **Edit** (document the variable) |

**2 new files, 7 edited**
**Tests: 4278 passing (39 new) | TypeScript: clean | Biome: clean | Security audit: 39/39**

---

## Disclosure

Written with AI assistance — the commit carries a `Co-Authored-By` trailer to that effect.

What that did and didn't mean here: the shape came from reading Appsmith's implementation,
and the two findings worth having — that `next.config.ts` bakes headers at build time, and
that the security audit was passing on a comment — both came from inspecting the running
container and from deliberately tampering with the audit to see whether it noticed. Neither
would have surfaced from reasoning about the source.

An earlier draft of this change was a boolean that disabled the protection outright. It was
rejected in review here as weakening the default, which is right, and the allow-list is what
replaced it.

I've read the diff and can walk through any part of it.
